### PR TITLE
GH-1 Add repo support

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,7 +16,7 @@ install:
 		terraform init
 
 clean:
-	rm -fR .terraform.d/ .terraform terraform.tfstate* terraform.d/
+	rm -fR .terraform.d/ .terraform terraform.tfstate* terraform.d/ .terraform.lock.hcl
 
 release:
 	@git tag v${NEXT_VERSION} && git push --mirror

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-# Terraform Provider Projects
+# Terraform Provider Project
 
-[![Actions Status](https://github.com/jfrog/terraform-provider-projects/workflows/release/badge.svg)](https://github.com/jfrog/terraform-provider-projects/actions)
-[![Go Report Card](https://goreportcard.com/badge/github.com/jfrog/terraform-provider-artifactory)](https://goreportcard.com/report/github.com/jfrog/terraform-provider-projects)
+[![Actions Status](https://github.com/jfrog/terraform-provider-project/workflows/release/badge.svg)](https://github.com/jfrog/terraform-provider-project/actions)
+[![Go Report Card](https://goreportcard.com/badge/github.com/jfrog/terraform-provider-project)](https://goreportcard.com/report/github.com/jfrog/terraform-provider-project)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/jfrog/terraform)
 
-To use this provider in your Terraform module, follow the documentation [here](https://registry.terraform.io/providers/jfrog/artifactory/latest/docs).
-
-
+To use this provider in your Terraform module, follow the documentation [here](https://registry.terraform.io/providers/jfrog/project/latest/docs).
 
 ## License requirements:
 
@@ -14,8 +12,8 @@ This provider requires access to the APIs, which are only available in the _lice
 You can determine which license you have by accessing the following URL
 `${host}/artifactory/api/system/licenses/`
 
-You can either access it via api, or web browser - it does require admin level credentials, but it's one of the few
-APIs that will work without a license (side node: you can also install your license here with a `POST`)
+You can either access it via api, or web browser - it does require admin level credentials, but it's one of the few APIs that will work without a license (side node: you can also install your license here with a `POST`)
+
 ```bash
 curl -sL ${host}/artifactory/api/system/licenses/ | jq .
 {
@@ -23,8 +21,8 @@ curl -sL ${host}/artifactory/api/system/licenses/ | jq .
   "validThrough" : "Jan 29, 2022",
   "licensedTo" : "JFrog Ltd"
 }
-
 ```
+
 The following 3 license types (`jq .type`) do **NOT** support APIs:
 - Community Edition for C/C++
 - JCR Edition
@@ -32,55 +30,51 @@ The following 3 license types (`jq .type`) do **NOT** support APIs:
 
 ## Limitations of functionality
 
+Currently this provider does not support the followings:
+- Xray support for the project
 
 ## Build the Provider
-Simply run `make install` - this will compile the provider and install it to `~/terraform.d`. When running this, it will
-take the current tag and bump it 1 minor version. It does not actually create a new tag (that is `make release`).
-If you wish to use the locally installed provider, make sure your TF script refers to the new version number
+
+Simply run `make install` - this will compile the provider and install it to `~/terraform.d`. When running this, it will take the current tag and bump it 1 minor version. It does not actually create a new tag (that is `make release`). If you wish to use the locally installed provider, make sure your TF script refers to the new version number.
 
 Requirements:
 - [Terraform](https://www.terraform.io/downloads.html) 0.13
 - [Go](https://golang.org/doc/install) 1.15+ (to build the provider plugin)
 
 ## Testing
-How to run the tests isn't obvious.
-First, you need a running instance of the jfrog platform (RT and XR). However, there is no currently supported dockerized, local
-version. You can ask for an instance to test against in as part of your PR or by messaging the maintainer in gitter
-Alternatively, you can run the file [scripts/run-artifactory.sh](scripts/run-artifactory.sh), which, if have a file in the same
-directory called `artifactory.lic`, you can start just an artifactory instance. The license is not supplied, but  a [30 day trial
-liscense can be freely obtained](https://jfrog.com/start-free/#hosted) and will allow local developement
 
-Once you have that done you must set the following properties
+How to run the tests isn't obvious.
+
+First, you need a running instance of the JFrog platform (RT and XR). However, there is no currently supported Dockerized, local version. You can ask for an instance to test against in as part of your PR or by messaging the maintainer in gitter.
+
+Alternatively, you can run the file [scripts/run-artifactory.sh](scripts/run-artifactory.sh), which, if you have a license file in the same directory called `artifactory.lic`, you can start just an artifactory instance. The license is not supplied, but a [30 day trial license can be freely obtained](https://jfrog.com/start-free/#hosted) and will allow local development.
 
 Then, you have to set some environment variables as this is how the acceptance tests pick up their config
+
 ```bash
-JFROG_URL=http://localhost:8081
-JFROG_ACCESS_TOKEN=...
+PROJECTS_URL=http://localhost:8081
+PROJECTS_ACCESS_TOKEN=...
 TF_ACC=true
 ```
-a crucial env var to set is
-`TF_ACC=true` - you can literally set `TF_ACC` to anything you want, so long as it's set. The acceptance tests use
-terraform testing libraries that, if this flag isn't set, will skip all tests. See [Terraform doc](https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html#running-acceptance-tests).
 
-You can then run the tests as
-`go test -v ./pkg/...`
-**DO NOT** remove the `-v` - terraform testing needs this (don't ask me why). This will recursively run all tests, including
-acceptance tests.
+A crucial env var to set is `TF_ACC=true` - you can literally set `TF_ACC` to anything you want, so long as it's set. The acceptance tests use terraform testing libraries that, if this flag isn't set, will skip all tests. See [Terraform doc](https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html#running-acceptance-tests).
+
+You can then run the tests with:
+```sh
+$ go test -v ./pkg/...
+```
+
+**DO NOT** omit the `-v` - terraform testing needs this (don't ask me why). This will recursively run all tests, including acceptance tests.
 
 ## Debugging
 
 ### Debugger-based debugging
 
-Debugging a terraform provider is not straightforward. Terraform forks your provider as a separate process and then
-connects to it via RPC. Normally, when debugging, you would start the process to debug directly. However, with the
-terraform + go architecture, this isn't possible. So, you need to run terraform as you normally would and attach to the
-provider process by getting it's pid. This would be really tricky considering how fast the process can come up and be down.
-So, you need to actually halt the provider and have it wait for your debugger to attach.
+Debugging a terraform provider is not straightforward. Terraform forks your provider as a separate process and then connects to it via RPC. Normally, when debugging, you would start the process to debug directly. However, with the terraform + go architecture, this isn't possible. So, you need to run terraform as you normally would and attach to the provider process by getting its pid. This would be really tricky considering how fast the process can come up and be down. So, you need to actually halt the provider and have it wait for your debugger to attach.
 
 Having said all that, here are the steps:
 1. Install [delve](https://github.com/go-delve/delve)
-2. Keep in mind that terraform will
-   parallel process if it can, and it will start new instances of the TF provider process when running apply between the plan and confirmation
+2. Keep in mind that terraform will parallel process if it can, and it will start new instances of the TF provider process when running apply between the plan and confirmation.
    Add a snippet of go code to the close to where you need to break where in you install a busy sleep loop:
 ```go
 	debug := true
@@ -88,8 +82,7 @@ Having said all that, here are the steps:
 		time.Sleep(time.Second) // set breakpoint here
 	}
 ```
-Then set a breakpoint inside the loop. Once you have attached to the process you can set the `debug` value to `false`,
-thus breaking the sleep loop and allow you to continue.
+Then set a breakpoint inside the loop. Once you have attached to the process you can set the `debug` value to `false`, thus breaking the sleep loop and allow you to continue.
 2. Compile the provider with debug symbology (`go build -gcflags "all=-N -l"`)
 3. Install the provider (change as needed for your version)
 ```bash
@@ -103,32 +96,36 @@ make install
 A 1-liner for this whole process is:
 `dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient attach $(pgrep terraform-provider-projects)`
 7. In intellij, setup a remote go debugging session (the default port is `2345`, but make sure it's set.) And click the `debug` button
-8. Your editor should immediately break at the breakpoint from step 2. At this point, in the watch window, edit the `debug`
-value and set it to false, and allow the debugger to continue. Be ready for your debugging as this will release the provider
-and continue executing normally.
+8. Your editor should immediately break at the breakpoint from step 2. At this point, in the watch window, edit the `debug` value and set it to false, and allow the debugger to continue. Be ready for your debugging as this will release the provider and continue executing normally.
 
-You will need to repeat steps 4-8 everytime you want to debug
+You will need to repeat steps 4-8 every time you want to debug
 
 ### Log-based debugging
 
-You can [turn on logging](https://www.terraform.io/docs/extend/debugging.html#turning-on-logging) for debug purpose by setting env var `TF_LOG` to `DEBUG`, i.e.
+You can [turn on logging](https://www.terraform.io/docs/extend/debugging.html#turning-on-logging) for debug purpose by setting env var `TF_LOG` to `DEBUG` or `TRACE`, i.e.
 
 ```sh
 export TF_LOG=DEBUG
 ```
 
-## Versioning
-In general, this project follows [semver](https://semver.org/) as closely as we
-can for tagging releases of the package. We've adopted the following versioning policy:
+Then use `log.Printf()` to print the data you want to the console.
 
-* We increment the **major version** with any incompatible change to
-	functionality, including changes to the exported Go API surface
-	or behavior of the API.
-* We increment the **minor version** with any backwards-compatible changes to
-	functionality.
+**Note** that you must include the log level as the prefix to the log message, e.g.
+
+```go
+log.Printf("[DEBUG] some thing happened")
+```
+
+## Versioning
+
+In general, this project follows [semver](https://semver.org/) as closely as we can for tagging releases of the package. We've adopted the following versioning policy:
+
+* We increment the **major version** with any incompatible change to functionality, including changes to the exported Go API surface or behavior of the API.
+* We increment the **minor version** with any backwards-compatible changes to functionality.
 * We increment the **patch version** with any backwards-compatible bug fixes.
 
 ## Contributors
+
 Pull requests, issues and comments are welcomed. For pull requests:
 
 * Add tests for new features and bug fixes
@@ -137,19 +134,15 @@ Pull requests, issues and comments are welcomed. For pull requests:
 
 See the existing issues for things to start contributing.
 
-For bigger changes, make sure you start a discussion first by creating
-an issue and explaining the intended change.
+For bigger changes, make sure you start a discussion first by creating an issue and explaining the intended change.
 
-JFrog requires contributors to sign a Contributor License Agreement,
-known as a CLA. This serves as a record stating that the contributor is
-entitled to contribute the code/documentation/translation to the project
-and is willing to have it used in distributions and derivative works
-(or is willing to transfer ownership).
+JFrog requires contributors to sign a Contributor License Agreement, known as a CLA. This serves as a record stating that the contributor is entitled to contribute the code/documentation/translation to the project and is willing to have it used in distributions and derivative works (or is willing to transfer ownership).
 
-[Sign the CLA](https://cla-assistant.io/jfrog/terraform-provider-projects)
+[Sign the CLA](https://cla-assistant.io/jfrog/terraform-provider-project)
 
 ## License
-Copyright (c) 2020 JFrog.
+
+Copyright (c) 2021 JFrog.
 
 Apache 2.0 licensed, see [LICENSE][LICENSE] file.
 

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -1,4 +1,4 @@
-#  Debugging a TerraForm provider 
+# Debugging a TerraForm provider
 
 ## Understanding the design
 
@@ -6,30 +6,20 @@ In order to do it, you first have to understand how Go builds apps, and then how
 
 Every terraform provider is a sort of `module`. In order to support an open, modular system, in almost any language, you need to be able to dynamically load modules and interact with them. Terraform is no exception.
 
-However, the go lang team long ago decided to compile to statically linked applications; 
-any dependencies you have will be compiled into 1 single binary. Unlike in other native languages (like C, or C++), a 
-`.dll` or `.so` is not used; there is no dynamic library to load at runtime and thus, modularity becomes a whole other trick.
-This is done to avoid the notorious **dll hell** that was so common up until most modern systems included some 
-kind of dependency management. And yes, it can still be an issue.
+However, the go lang team long ago decided to compile to statically linked applications; any dependencies you have will be compiled into 1 single binary. Unlike in other native languages (like C, or C++), a `.dll` or `.so` is not used; there is no dynamic library to load at runtime and thus, modularity becomes a whole other trick. This is done to avoid the notorious **dll hell** that was so common up until most modern systems included some kind of dependency management. And yes, it can still be an issue.
 
-Every terraform provider is its own mini RPC server. When terraform runs your provider, it actually starts a new process that is your provider, and connects to it through 
-this RPC channel. Compounding the problem is that the lifetime of your provider process is very much 
-ephemeral; potentially lasting no more and a few seconds. It's this process you need to connect to with your debugger
+Every terraform provider is its own mini RPC server. When terraform runs your provider, it actually starts a new process that is your provider, and connects to it through this RPC channel. Compounding the problem is that the lifetime of your provider process is very much ephemeral; potentially lasting no more and a few seconds. It's this process you need to connect to with your debugger
 
 ### Normal debugging
-Normally, you would directly spin-up your app, and it would load modules into application memory. That's why you can actually
-debug it, because your debugger knows how to find the exact memory address for your provider. However, you don't have 
-this arrangement, and you need to do a _remote_ debug session. 
+Normally, you would directly spin-up your app, and it would load modules into application memory. That's why you can actually debug it, because your debugger knows how to find the exact memory address for your provider. However, you don't have this arrangement, and you need to do a _remote_ debug session.
 
 ### The conundrum
-So, you don't load terraform directly, and even if you did, your `module` (a.k.a your provider) is in the memory 
-space of an entirely different process; and that lasts no more than a few seconds, potentially.  
+So, you don't load terraform directly, and even if you did, your `module` (a.k.a your provider) is in the memory space of an entirely different process; and that lasts no more than a few seconds, potentially.  
 
 ## The solution
 
 1. You need the debugging tool [delve](https://github.com/go-delve/delve).
-2. You are going to have to place a little bit of shim code close to the spot in the code where you want to begin
-debugging. We need to stop this provider process from exiting before we can connect. So, put this bit of code in place:
+2. You are going to have to place a little bit of shim code close to the spot in the code where you want to begin debugging. We need to stop this provider process from exiting before we can connect. So, put this bit of code in place:
 ```go
 	connected := false
 	for !connected {
@@ -38,14 +28,11 @@ debugging. We need to stop this provider process from exiting before we can conn
 ```
 This code effectively creates an infinite sleep loop; but that's actually essential to solving the problem.
 
-3. Place a break point right inside this loop. It won't do anything, yet. 
-4. Now run the terraform commands you need to, to engage the code you're desiring to debug. Upon doing so,
-terraform will basically stop, as it waits on a response from you provider; because you put an infinite sleep loop in
-5. You must now tell `delve` to connect to this remote process using it's PID. This isn't as hard as it seems.
+3. Place a break point right inside this loop. It won't do anything, yet.
+4. Now run the terraform commands you need to, to engage the code you're desiring to debug. Upon doing so, terraform will basically stop, as it waits on a response from you provider; because you put an infinite sleep loop in
+5. You must now tell `delve` to connect to this remote process using its PID. This isn't as hard as it seems.
 Run this commands:
 `dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient attach $(pgrep terraform-provider-artifactory)`
-The last argument gets the `PID` for your provider and supplies it to `delve` to connect. Immediately upon running this 
-command, you're going to hit your break point. Please make sure to substitute `terraform-provider-artifactory` for your provider name
-6. To exit this infinite loop, use your debugger to set `connected` to `true`. By doing so you change the loop predicate 
-and it will exit this loop on the next iteration.
-7. *DEBUG!* - At this point you can, step, watch, drop the call stack, etc. Your whole arsenel is available
+The last argument gets the `PID` for your provider and supplies it to `delve` to connect. Immediately upon running this command, you're going to hit your break point. Please make sure to substitute `terraform-provider-artifactory` for your provider name
+6. To exit this infinite loop, use your debugger to set `connected` to `true`. By doing so you change the loop predicate and it will exit this loop on the next iteration.
+7. *DEBUG!* - At this point you can, step, watch, drop the call stack, etc. Your whole arsenal is available

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,13 +66,37 @@ resource "project" "myproject" {
   }
 
   group {
-    name = "dev-group"
+    name  = "dev-group"
     roles = ["developer"]
   }
 
   group {
-    name = "release-group"
+    name  = "release-group"
     roles = ["release manager"]
+  }
+
+  role {
+    name         = "developer"
+    description  = "Developer role"
+    type         = "CUSTOM"
+    environments = ["DEV"]
+    actions      = ["READ_REPOSITORY", "ANNOTATE_REPOSITORY", "DEPLOY_CACHE_REPOSITORY", "DELETE_OVERWRITE_REPOSITORY", "TRIGGER_PIPELINE", "READ_INTEGRATIONS_PIPELINE", "READ_POOLS_PIPELINE", "MANAGE_INTEGRATIONS_PIPELINE", "MANAGE_SOURCES_PIPELINE", "MANAGE_POOLS_PIPELINE"]
+  }
+
+  role {
+    name         = "devop"
+    description  = "DevOp role"
+    type         = "CUSTOM"
+    environments = ["DEV", "PROD"]
+    actions      = ["READ_REPOSITORY", "ANNOTATE_REPOSITORY", "DEPLOY_CACHE_REPOSITORY", "DELETE_OVERWRITE_REPOSITORY", "TRIGGER_PIPELINE", "READ_INTEGRATIONS_PIPELINE", "READ_POOLS_PIPELINE", "MANAGE_INTEGRATIONS_PIPELINE", "MANAGE_SOURCES_PIPELINE", "MANAGE_POOLS_PIPELINE", "READ_BUILD", "ANNOTATE_BUILD", "DEPLOY_BUILD", "DELETE_BUILD",]
+  }
+
+  repo {
+    name = "docker-local"
+  }
+
+  repo {
+    name = "rpm-local"
   }
 }
 ```
@@ -82,6 +106,7 @@ resource "project" "myproject" {
 The Artifactory Project provider supports one type of authentication using Bearer token.
 
 ### Bearer Token
+
 Artifactory access tokens may be used via the Authorization header by providing the `access_token` field to the provider block. Getting this value from the environment is supported with the `PROJECTS_ACCESS_TOKEN` or `JFROG_ACCESS_TOKEN` environment variable
 
 Usage:

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -45,6 +45,30 @@ resource "project" "myproject" {
     name = "release-group"
     roles = ["release manager"]
   }
+
+  role {
+    name         = "developer"
+    description  = "Developer role"
+    type         = "CUSTOM"
+    environments = ["DEV"]
+    actions      = ["READ_REPOSITORY", "ANNOTATE_REPOSITORY", "DEPLOY_CACHE_REPOSITORY", "DELETE_OVERWRITE_REPOSITORY", "TRIGGER_PIPELINE", "READ_INTEGRATIONS_PIPELINE", "READ_POOLS_PIPELINE", "MANAGE_INTEGRATIONS_PIPELINE", "MANAGE_SOURCES_PIPELINE", "MANAGE_POOLS_PIPELINE"]
+  }
+
+  role {
+    name         = "devop"
+    description  = "DevOp role"
+    type         = "CUSTOM"
+    environments = ["DEV", "PROD"]
+    actions      = ["READ_REPOSITORY", "ANNOTATE_REPOSITORY", "DEPLOY_CACHE_REPOSITORY", "DELETE_OVERWRITE_REPOSITORY", "TRIGGER_PIPELINE", "READ_INTEGRATIONS_PIPELINE", "READ_POOLS_PIPELINE", "MANAGE_INTEGRATIONS_PIPELINE", "MANAGE_SOURCES_PIPELINE", "MANAGE_POOLS_PIPELINE", "READ_BUILD", "ANNOTATE_BUILD", "DEPLOY_BUILD", "DELETE_BUILD",]
+  }
+
+  repo {
+    name = "docker-local"
+  }
+
+  repo {
+    name = "rpm-local"
+  }
 }
 ```
 
@@ -66,6 +90,7 @@ resource "project" "myproject" {
 - **id** (String) The ID of this resource.
 - **max_storage_in_gibibytes** (Number) Storage quota in GiB. Must be 1 or larger. Set to -1 for unlimited storage. This is translated to binary bytes for Artifactory API. So for 1TB quota, this should be set to 1024 (vs 1000) which will translate to 1099511627776 bytes for the API.
 - **member** (Block Set) Member of the project. Element has one to one mapping with the [JFrog Project Users API](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-UpdateUserinProject). (see [below for nested schema](#nestedblock--member))
+- **repo** (Block Set) Existing repo to be assigned to the project. (see [below for nested schema](#nestedblock--repo))
 - **role** (Block Set) Project role. Element has one to one mapping with the [JFrog Project Roles API](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-AddaNewRole) (see [below for nested schema](#nestedblock--role))
 
 <a id="nestedblock--admin_privileges"></a>
@@ -94,6 +119,14 @@ Required:
 
 - **name** (String) Must be existing Artifactory user
 - **roles** (Set of String) List of pre-defined Project or custom roles
+
+
+<a id="nestedblock--repo"></a>
+### Nested Schema for `repo`
+
+Required:
+
+- **name** (String) Repository key
 
 
 <a id="nestedblock--role"></a>

--- a/examples/resources/project/resource.tf
+++ b/examples/resources/project/resource.tf
@@ -30,4 +30,28 @@ resource "project" "myproject" {
     name = "release-group"
     roles = ["release manager"]
   }
+
+  role {
+    name         = "developer"
+    description  = "Developer role"
+    type         = "CUSTOM"
+    environments = ["DEV"]
+    actions      = ["READ_REPOSITORY", "ANNOTATE_REPOSITORY", "DEPLOY_CACHE_REPOSITORY", "DELETE_OVERWRITE_REPOSITORY", "TRIGGER_PIPELINE", "READ_INTEGRATIONS_PIPELINE", "READ_POOLS_PIPELINE", "MANAGE_INTEGRATIONS_PIPELINE", "MANAGE_SOURCES_PIPELINE", "MANAGE_POOLS_PIPELINE"]
+  }
+
+  role {
+    name         = "devop"
+    description  = "DevOp role"
+    type         = "CUSTOM"
+    environments = ["DEV", "PROD"]
+    actions      = ["READ_REPOSITORY", "ANNOTATE_REPOSITORY", "DEPLOY_CACHE_REPOSITORY", "DELETE_OVERWRITE_REPOSITORY", "TRIGGER_PIPELINE", "READ_INTEGRATIONS_PIPELINE", "READ_POOLS_PIPELINE", "MANAGE_INTEGRATIONS_PIPELINE", "MANAGE_SOURCES_PIPELINE", "MANAGE_POOLS_PIPELINE", "READ_BUILD", "ANNOTATE_BUILD", "DEPLOY_BUILD", "DELETE_BUILD",]
+  }
+
+  repo {
+    name = "docker-local"
+  }
+
+  repo {
+    name = "rpm-local"
+  }
 }

--- a/pkg/projects/resource_project.go
+++ b/pkg/projects/resource_project.go
@@ -221,13 +221,14 @@ func projectResource() *schema.Resource {
 			Optional: true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
-					"name": {
+					"key": {
 						Type:     schema.TypeString,
 						Required: true,
 						ValidateDiagFunc: validation.ToDiagFunc(validation.All(
 							validation.StringIsNotEmpty,
 							maxLength(64),
 						)),
+						Description: "Repository key",
 					},
 				},
 			},

--- a/pkg/projects/resource_project_membership_test.go
+++ b/pkg/projects/resource_project_membership_test.go
@@ -87,12 +87,12 @@ func TestAccProjectMember(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			createTestUser(t, projectKey, username1, email1)
-			createTestUser(t, projectKey, username2, email2)
+			createTestUser(t, username1, email1)
+			createTestUser(t, username2, email2)
 		},
 		CheckDestroy: verifyDeleted(resourceName, func(id string, request *resty.Request) (*resty.Response, error) {
-			deleteTestUser(t, projectKey, username1)
-			deleteTestUser(t, projectKey, username2)
+			deleteTestUser(t, username1)
+			deleteTestUser(t, username2)
 			resp, err := verifyProject(id, request)
 
 			return resp, err
@@ -216,12 +216,12 @@ func TestAccProjectGroup(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			createTestGroup(t, projectKey, group1)
-			createTestGroup(t, projectKey, group2)
+			createTestGroup(t, group1)
+			createTestGroup(t, group2)
 		},
 		CheckDestroy: verifyDeleted(resourceName, func(id string, request *resty.Request) (*resty.Response, error) {
-			deleteTestGroup(t, projectKey, group1)
-			deleteTestGroup(t, projectKey, group2)
+			deleteTestGroup(t, group1)
+			deleteTestGroup(t, group2)
 			resp, err := verifyProject(id, request)
 
 			return resp, err

--- a/pkg/projects/resource_project_repo.go
+++ b/pkg/projects/resource_project_repo.go
@@ -1,0 +1,202 @@
+package projects
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type Repo struct {
+	Name string
+}
+
+func (this Repo) Id() string {
+	return this.Name
+}
+
+func (this Repo) Equals(other Identifiable) bool {
+	return this.Id() == other.Id()
+}
+
+func reposToEquatables(repos []Repo) []Equatable {
+	var equatables []Equatable
+
+	for _, repo := range repos {
+		equatables = append(equatables, repo)
+	}
+
+	return equatables
+}
+
+func equatablesToRepos(equatables []Equatable) []Repo {
+	var repos []Repo
+
+	for _, equatable := range equatables {
+		repos = append(repos, equatable.(Repo))
+	}
+
+	return repos
+}
+
+var unpackRepos = func(data *schema.ResourceData) []Repo {
+	d := &ResourceData{data}
+
+	var repos []Repo
+
+	if v, ok := d.GetOkExists("repo"); ok {
+		projectRepos := v.(*schema.Set).List()
+		if len(projectRepos) == 0 {
+			return repos
+		}
+
+		for _, projectRepo := range projectRepos {
+			id := projectRepo.(map[string]interface{})
+
+			repo := Repo{
+				Name:      id["name"].(string),
+			}
+			repos = append(repos, repo)
+		}
+	}
+
+	return repos
+}
+
+var packRepos = func(d *schema.ResourceData, repos []Repo) []error {
+	log.Printf("[DEBUG] packRepos")
+
+	setValue := mkLens(d)
+
+	var projectRepos []interface{}
+
+	for _, repo := range repos {
+		log.Printf("[TRACE] %+v\n", repo)
+		projectRepo := map[string]interface{}{
+			"name":  repo.Name,
+		}
+
+		projectRepos = append(projectRepos, projectRepo)
+	}
+
+	log.Printf("[TRACE] %+v\n", projectRepos)
+
+	errors := setValue("repo", projectRepos)
+
+	return errors
+}
+
+var readRepos = func(projectKey string, m interface{}) ([]Repo, error) {
+	log.Println("[DEBUG] readRepos")
+
+	type ArtifactoryRepo struct {
+		Key string
+	}
+
+	artifactoryRepos := []ArtifactoryRepo{}
+
+	_, err := m.(*resty.Client).R().
+		SetPathParam("projectKey", projectKey).
+		SetResult(&artifactoryRepos).
+		Get("/artifactory/api/repositories?project={projectKey}")
+
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("[TRACE] artifactoryRepos: %+v\n", artifactoryRepos)
+
+	var repos []Repo
+	for _, artifactoryRepo := range artifactoryRepos {
+		repo := Repo{
+			Name: artifactoryRepo.Key,
+		}
+		repos = append(repos, repo)
+	}
+	log.Printf("[TRACE] repos: %+v\n", repos)
+
+	return repos, nil
+}
+
+var updateRepos = func(projectKey string, terraformRepos []Repo, m interface{}) ([]Repo, error) {
+	log.Println("[DEBUG] updateRepos")
+	log.Printf("[TRACE] terraformRepos: %+v\n", terraformRepos)
+
+	projectRepos, err := readRepos(projectKey, m)
+	log.Printf("[TRACE] projectRepos: %+v\n", projectRepos)
+
+	reposToBeAdded := difference(reposToEquatables(terraformRepos), reposToEquatables(projectRepos))
+	log.Printf("[TRACE] reposToBeAdded: %+v\n", reposToBeAdded)
+
+	reposToBeDeleted := difference(reposToEquatables(projectRepos), reposToEquatables(terraformRepos))
+	log.Printf("[TRACE] reposToBeDeleted: %+v\n", reposToBeDeleted)
+
+	var errs []error
+
+	for _, repo := range reposToBeAdded {
+		log.Printf("[TRACE] %+v\n", repo)
+		err := addRepo(projectKey, repo.(Repo), m)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	err = deleteRepos(projectKey, equatablesToRepos(reposToBeDeleted), m)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("failed to update repos for project: %s", errs)
+	}
+
+	return readRepos(projectKey, m)
+}
+
+var addRepo = func(projectKey string, repo Repo, m interface{}) error {
+	log.Println("[DEBUG] addRepo")
+
+	_, err := m.(*resty.Client).R().
+		SetPathParams(map[string]string{
+			"projectKey": projectKey,
+			"repoName":   repo.Name,
+		}).
+		SetQueryParam("force", "true").
+		Put(projectsUrl + "/_/attach/repositories/{repoName}/{projectKey}")
+
+	return err
+}
+
+var deleteRepos = func(projectKey string, repos []Repo, m interface{}) error {
+	log.Println("[DEBUG] deleteRepos")
+
+	var errs []error
+	for _, repo := range repos {
+		err := deleteRepo(projectKey, repo, m)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to delete repos from project: %v", errs)
+	}
+
+	return nil
+}
+
+var deleteRepo = func(projectKey string, repo Repo, m interface{}) error {
+	log.Println("[DEBUG] deleteRepo")
+	log.Printf("[TRACE] %+v\n", repo)
+
+	_, err := m.(*resty.Client).R().
+		SetPathParam("repoName", repo.Name).
+		Delete(projectsUrl + "/_/attach/repositories/{repoName}")
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/projects/resource_project_repo_test.go
+++ b/pkg/projects/resource_project_repo_test.go
@@ -36,7 +36,7 @@ func TestAccProjectRepo(t *testing.T) {
 			}
 
 			repo {
-				name  = "{{ .repo1 }}"
+				key = "{{ .repo1 }}"
 			}
 		}
 	`, params)
@@ -53,11 +53,11 @@ func TestAccProjectRepo(t *testing.T) {
 			}
 
 			repo {
-				name  = "{{ .repo1 }}"
+				key = "{{ .repo1 }}"
 			}
 
 			repo {
-				name  = "{{ .repo2 }}"
+				key = "{{ .repo2 }}"
 			}
 		}
 	`, params)
@@ -96,7 +96,7 @@ func TestAccProjectRepo(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "key", fmt.Sprintf("%s", params["project_key"])),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
 					resource.TestCheckResourceAttr(resourceName, "repo.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "repo.0.name", repo1),
+					resource.TestCheckResourceAttr(resourceName, "repo.0.key", repo1),
 				),
 			},
 			{
@@ -106,8 +106,8 @@ func TestAccProjectRepo(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "display_name", name),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
 					resource.TestCheckResourceAttr(resourceName, "repo.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "repo.0.name", repo1),
-					resource.TestCheckResourceAttr(resourceName, "repo.1.name", repo2),
+					resource.TestCheckResourceAttr(resourceName, "repo.0.key", repo1),
+					resource.TestCheckResourceAttr(resourceName, "repo.1.key", repo2),
 				),
 			},
 			{

--- a/pkg/projects/resource_project_repo_test.go
+++ b/pkg/projects/resource_project_repo_test.go
@@ -1,0 +1,124 @@
+package projects
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccProjectRepo(t *testing.T) {
+	name := "tftestprojects" + randSeq(10)
+	resourceName := "project." + name
+	projectKey := strings.ToLower(randSeq(6))
+
+	repo1 := "repo1"
+	repo2 := "repo2"
+
+	params := map[string]interface{}{
+		"name":        name,
+		"project_key": projectKey,
+		"repo1":       repo1,
+		"repo2":       repo2,
+	}
+
+	initialConfig := executeTemplate("TestAccProjectRepo", `
+		resource "project" "{{ .name }}" {
+			key = "{{ .project_key }}"
+			display_name = "{{ .name }}"
+			description = "test description"
+			admin_privileges {
+				manage_members = true
+				manage_resources = true
+				index_resources = true
+			}
+
+			repo {
+				name  = "{{ .repo1 }}"
+			}
+		}
+	`, params)
+
+	addRepoConfig := executeTemplate("TestAccProjectRepo", `
+		resource "project" "{{ .name }}" {
+			key = "{{ .project_key }}"
+			display_name = "{{ .name }}"
+			description = "test description"
+			admin_privileges {
+				manage_members = true
+				manage_resources = true
+				index_resources = true
+			}
+
+			repo {
+				name  = "{{ .repo1 }}"
+			}
+
+			repo {
+				name  = "{{ .repo2 }}"
+			}
+		}
+	`, params)
+
+	noReposConfig := executeTemplate("TestAccProjectRepo", `
+		resource "project" "{{ .name }}" {
+			key = "{{ .project_key }}"
+			display_name = "{{ .name }}"
+			description = "test description"
+			admin_privileges {
+				manage_members = true
+				manage_resources = true
+				index_resources = true
+			}
+		}
+	`, params)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			createTestRepo(t, repo1)
+			createTestRepo(t, repo2)
+		},
+		CheckDestroy: verifyDeleted(resourceName, func(id string, request *resty.Request) (*resty.Response, error) {
+			deleteTestRepo(t, repo1)
+			deleteTestRepo(t, repo2)
+			resp, err := verifyProject(id, request)
+
+			return resp, err
+		}),
+		ProviderFactories: testAccProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: initialConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "key", fmt.Sprintf("%s", params["project_key"])),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "repo.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "repo.0.name", repo1),
+				),
+			},
+			{
+				Config: addRepoConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "key", fmt.Sprintf("%s", params["project_key"])),
+					resource.TestCheckResourceAttr(resourceName, "display_name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "repo.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "repo.0.name", repo1),
+					resource.TestCheckResourceAttr(resourceName, "repo.1.name", repo2),
+				),
+			},
+			{
+				Config: noReposConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "key", fmt.Sprintf("%s", params["project_key"])),
+					resource.TestCheckResourceAttr(resourceName, "display_name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckNoResourceAttr(resourceName, "repo"),
+				),
+			},
+		},
+	})
+}

--- a/pkg/projects/util_test.go
+++ b/pkg/projects/util_test.go
@@ -154,7 +154,7 @@ func randSelect(items ...interface{}) interface{} {
 	return items[randomInt()%len(items)]
 }
 
-func createTestUser(t *testing.T, projectKey string, name string, email string) {
+func createTestUser(t *testing.T, name string, email string) {
 
 	type ArtifactoryUser struct {
 		Email    string `json:"email"`
@@ -176,7 +176,7 @@ func createTestUser(t *testing.T, projectKey string, name string, email string) 
 	}
 }
 
-func deleteTestUser(t *testing.T, projectKey string, name string) {
+func deleteTestUser(t *testing.T, name string) {
 	restyClient := getTestResty(t)
 
 	_, err := restyClient.R().Delete("/artifactory/api/security/users/" + name)
@@ -185,7 +185,7 @@ func deleteTestUser(t *testing.T, projectKey string, name string) {
 	}
 }
 
-func createTestGroup(t *testing.T, projectKey string, name string) {
+func createTestGroup(t *testing.T, name string) {
 
 	type ArtifactoryGroup struct {
 		Name string `json:"name"`
@@ -203,10 +203,39 @@ func createTestGroup(t *testing.T, projectKey string, name string) {
 	}
 }
 
-func deleteTestGroup(t *testing.T, projectKey string, name string) {
+func deleteTestGroup(t *testing.T, name string) {
 	restyClient := getTestResty(t)
 
 	_, err := restyClient.R().Delete("/artifactory/api/security/groups/" + name)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createTestRepo(t *testing.T, name string) {
+
+	type ArtifactoryRepo struct {
+		Name    string `json:"key"`
+		RClass  string `json:"rclass"`
+	}
+
+	restyClient := getTestResty(t)
+
+	repo := ArtifactoryRepo{
+		Name:   name,
+		RClass: "local",
+	}
+
+	_, err := restyClient.R().SetBody(repo).Put("/artifactory/api/repositories/" + name)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func deleteTestRepo(t *testing.T, name string) {
+	restyClient := getTestResty(t)
+
+	_, err := restyClient.R().Delete("/artifactory/api/repositories/" + name)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sample.tf
+++ b/sample.tf
@@ -32,12 +32,36 @@ resource "project" "myproject" {
   }
 
   group {
-    name = "dev-group"
+    name  = "dev-group"
     roles = ["developer"]
   }
 
   group {
-    name = "release-group"
+    name  = "release-group"
     roles = ["release manager"]
+  }
+
+  role {
+    name         = "developer"
+    description  = "Developer role"
+    type         = "CUSTOM"
+    environments = ["DEV"]
+    actions      = ["READ_REPOSITORY", "ANNOTATE_REPOSITORY", "DEPLOY_CACHE_REPOSITORY", "DELETE_OVERWRITE_REPOSITORY", "TRIGGER_PIPELINE", "READ_INTEGRATIONS_PIPELINE", "READ_POOLS_PIPELINE", "MANAGE_INTEGRATIONS_PIPELINE", "MANAGE_SOURCES_PIPELINE", "MANAGE_POOLS_PIPELINE"]
+  }
+
+  role {
+    name         = "devop"
+    description  = "DevOp role"
+    type         = "CUSTOM"
+    environments = ["DEV", "PROD"]
+    actions      = ["READ_REPOSITORY", "ANNOTATE_REPOSITORY", "DEPLOY_CACHE_REPOSITORY", "DELETE_OVERWRITE_REPOSITORY", "TRIGGER_PIPELINE", "READ_INTEGRATIONS_PIPELINE", "READ_POOLS_PIPELINE", "MANAGE_INTEGRATIONS_PIPELINE", "MANAGE_SOURCES_PIPELINE", "MANAGE_POOLS_PIPELINE", "READ_BUILD", "ANNOTATE_BUILD", "DEPLOY_BUILD", "DELETE_BUILD",]
+  }
+
+  repo {
+    name = "docker-local"
+  }
+
+  repo {
+    name = "rpm-local"
   }
 }

--- a/templates/debug.md
+++ b/templates/debug.md
@@ -1,4 +1,4 @@
-#  Debugging a TerraForm provider 
+# Debugging a TerraForm provider
 
 ## Understanding the design
 
@@ -6,30 +6,20 @@ In order to do it, you first have to understand how Go builds apps, and then how
 
 Every terraform provider is a sort of `module`. In order to support an open, modular system, in almost any language, you need to be able to dynamically load modules and interact with them. Terraform is no exception.
 
-However, the go lang team long ago decided to compile to statically linked applications; 
-any dependencies you have will be compiled into 1 single binary. Unlike in other native languages (like C, or C++), a 
-`.dll` or `.so` is not used; there is no dynamic library to load at runtime and thus, modularity becomes a whole other trick.
-This is done to avoid the notorious **dll hell** that was so common up until most modern systems included some 
-kind of dependency management. And yes, it can still be an issue.
+However, the go lang team long ago decided to compile to statically linked applications; any dependencies you have will be compiled into 1 single binary. Unlike in other native languages (like C, or C++), a `.dll` or `.so` is not used; there is no dynamic library to load at runtime and thus, modularity becomes a whole other trick. This is done to avoid the notorious **dll hell** that was so common up until most modern systems included some kind of dependency management. And yes, it can still be an issue.
 
-Every terraform provider is its own mini RPC server. When terraform runs your provider, it actually starts a new process that is your provider, and connects to it through 
-this RPC channel. Compounding the problem is that the lifetime of your provider process is very much 
-ephemeral; potentially lasting no more and a few seconds. It's this process you need to connect to with your debugger
+Every terraform provider is its own mini RPC server. When terraform runs your provider, it actually starts a new process that is your provider, and connects to it through this RPC channel. Compounding the problem is that the lifetime of your provider process is very much ephemeral; potentially lasting no more and a few seconds. It's this process you need to connect to with your debugger
 
 ### Normal debugging
-Normally, you would directly spin-up your app, and it would load modules into application memory. That's why you can actually
-debug it, because your debugger knows how to find the exact memory address for your provider. However, you don't have 
-this arrangement, and you need to do a _remote_ debug session. 
+Normally, you would directly spin-up your app, and it would load modules into application memory. That's why you can actually debug it, because your debugger knows how to find the exact memory address for your provider. However, you don't have this arrangement, and you need to do a _remote_ debug session.
 
 ### The conundrum
-So, you don't load terraform directly, and even if you did, your `module` (a.k.a your provider) is in the memory 
-space of an entirely different process; and that lasts no more than a few seconds, potentially.  
+So, you don't load terraform directly, and even if you did, your `module` (a.k.a your provider) is in the memory space of an entirely different process; and that lasts no more than a few seconds, potentially.  
 
 ## The solution
 
 1. You need the debugging tool [delve](https://github.com/go-delve/delve).
-2. You are going to have to place a little bit of shim code close to the spot in the code where you want to begin
-debugging. We need to stop this provider process from exiting before we can connect. So, put this bit of code in place:
+2. You are going to have to place a little bit of shim code close to the spot in the code where you want to begin debugging. We need to stop this provider process from exiting before we can connect. So, put this bit of code in place:
 ```go
 	connected := false
 	for !connected {
@@ -38,14 +28,11 @@ debugging. We need to stop this provider process from exiting before we can conn
 ```
 This code effectively creates an infinite sleep loop; but that's actually essential to solving the problem.
 
-3. Place a break point right inside this loop. It won't do anything, yet. 
-4. Now run the terraform commands you need to, to engage the code you're desiring to debug. Upon doing so,
-terraform will basically stop, as it waits on a response from you provider; because you put an infinite sleep loop in
-5. You must now tell `delve` to connect to this remote process using it's PID. This isn't as hard as it seems.
+3. Place a break point right inside this loop. It won't do anything, yet.
+4. Now run the terraform commands you need to, to engage the code you're desiring to debug. Upon doing so, terraform will basically stop, as it waits on a response from you provider; because you put an infinite sleep loop in
+5. You must now tell `delve` to connect to this remote process using its PID. This isn't as hard as it seems.
 Run this commands:
 `dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient attach $(pgrep terraform-provider-artifactory)`
-The last argument gets the `PID` for your provider and supplies it to `delve` to connect. Immediately upon running this 
-command, you're going to hit your break point. Please make sure to substitute `terraform-provider-artifactory` for your provider name
-6. To exit this infinite loop, use your debugger to set `connected` to `true`. By doing so you change the loop predicate 
-and it will exit this loop on the next iteration.
-7. *DEBUG!* - At this point you can, step, watch, drop the call stack, etc. Your whole arsenel is available
+The last argument gets the `PID` for your provider and supplies it to `delve` to connect. Immediately upon running this command, you're going to hit your break point. Please make sure to substitute `terraform-provider-artifactory` for your provider name
+6. To exit this infinite loop, use your debugger to set `connected` to `true`. By doing so you change the loop predicate and it will exit this loop on the next iteration.
+7. *DEBUG!* - At this point you can, step, watch, drop the call stack, etc. Your whole arsenal is available

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -38,6 +38,7 @@ The following 3 license types (`jq .type`) do **NOT** support APIs:
 The Artifactory Project provider supports one type of authentication using Bearer token.
 
 ### Bearer Token
+
 Artifactory access tokens may be used via the Authorization header by providing the `access_token` field to the provider block. Getting this value from the environment is supported with the `PROJECTS_ACCESS_TOKEN` or `JFROG_ACCESS_TOKEN` environment variable
 
 Usage:


### PR DESCRIPTION
The resource `project.repo` is defined as a `TypeSet` with one attribute `key`. Even though a plain `TypeSet` of `string` will provide same functionality, the use of a structure let us apply validation and easy mapping from the Artifactory REST API response.