### PR TITLE
Support prerelease semver in make file

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ install:
 		(test -f ${BINARY_NAME} || go build -o ./${BINARY_NAME} -ldflags="-X '${PKG_VERSION_PATH}.Version=${NEXT_VERSION}'") && \
 		mv ${BINARY_NAME} ${BUILD_PATH} && \
 		rm -f .terraform.lock.hcl && \
-		sed -ie 's/version = ".*"/version = "${NEXT_VERSION}"/' sample.tf && \
+		sed -i 's/version = ".*"/version = "${NEXT_VERSION}"/' sample.tf && \
 		terraform init
 
 clean:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,7 +2,7 @@ TEST?=./...
 TARGET_ARCH?=darwin_amd64
 PKG_NAME=pkg/projects
 PKG_VERSION_PATH=github.com/jfrog/terraform-provider-project/${PKG_NAME}
-VERSION := $(shell git tag --sort=-creatordate | head -1 | sed  -n 's/v\([0-9]*\).\([0-9]*\).\([0-9]*\)/\1.\2.\3/p')
+VERSION := $(shell git tag --sort=-creatordate | head -1 | sed -n 's/v\([0-9]*\).\([0-9]*\).\([0-9]*\)\(?:.*\)/\1.\2.\3/p')
 NEXT_VERSION := $(shell echo ${VERSION}| awk -F '.' '{print $$1 "." $$2 "." $$3 +1 }' )
 BINARY_NAME=terraform-provider-project
 BUILD_PATH=terraform.d/plugins/registry.terraform.io/jfrog/project/${NEXT_VERSION}/${TARGET_ARCH}

--- a/README.md
+++ b/README.md
@@ -190,6 +190,26 @@ Simply run `make install` - this will compile the provider and install it to `~/
 Requirements:
 - [Terraform](https://www.terraform.io/downloads.html) 0.13
 - [Go](https://golang.org/doc/install) 1.15+ (to build the provider plugin)
+- [gnu-sed](https://formulae.brew.sh/formula/gnu-sed)
+
+### gnu-sed
+
+After installing with brew, get the GNU sed information:
+
+```sh
+$ brew info gnu-sed
+```
+
+You should see something like:
+```
+GNU "sed" has been installed as "gsed".
+If you need to use it as "sed", you can add a "gnubin" directory
+to your PATH from your bashrc like:
+
+     PATH="$(brew --prefix)/opt/gnu-sed/libexec/gnubin:$PATH"
+```
+
+Add the `gnubin` directory to your `.bashrc` or `.zshrc`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -190,11 +190,16 @@ Simply run `make install` - this will compile the provider and install it to `~/
 Requirements:
 - [Terraform](https://www.terraform.io/downloads.html) 0.13
 - [Go](https://golang.org/doc/install) 1.15+ (to build the provider plugin)
-- [gnu-sed](https://formulae.brew.sh/formula/gnu-sed)
 
-### gnu-sed
+### Building on macOS
 
-This provider uses [GNU sed](https://www.gnu.org/software/sed/) as part of the build toolchain, in both Linux and macOS. This provides consistency across OSes. If you are building this on macOS, you will need to install [gnu-sed using brew](https://formulae.brew.sh/formula/gnu-sed).
+This provider uses [GNU sed](https://www.gnu.org/software/sed/) as part of the build toolchain, in both Linux and macOS. This provides consistency across OSes.
+
+If you are building this on macOS, you have two options:
+- Install [gnu-sed using brew](https://formulae.brew.sh/formula/gnu-sed), OR
+- Use a Linux Docker image/container
+
+#### Using gnu-sed
 
 After installing with brew, get the GNU sed information:
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Requirements:
 
 ### gnu-sed
 
+This provider uses [GNU sed](https://www.gnu.org/software/sed/) as part of the build toolchain, in both Linux and macOS. This provides consistency across OSes. If you are building this on macOS, you will need to install [gnu-sed using brew](https://formulae.brew.sh/formula/gnu-sed).
+
 After installing with brew, get the GNU sed information:
 
 ```sh
@@ -209,7 +211,7 @@ to your PATH from your bashrc like:
      PATH="$(brew --prefix)/opt/gnu-sed/libexec/gnubin:$PATH"
 ```
 
-Add the `gnubin` directory to your `.bashrc` or `.zshrc`.
+Add the `gnubin` directory to your `.bashrc` or `.zshrc` per instruction so that `sed` command uses gnu-sed.
 
 ## Testing
 


### PR DESCRIPTION
Revert the ‘e’ backup extension when execute with GNU sed. Add info on GNU sed installation to README