### PR TITLE
Use singular form of the license API endpoint

### DIFF
--- a/pkg/projects/provider.go
+++ b/pkg/projects/provider.go
@@ -114,7 +114,7 @@ func checkArtifactoryLicense(client *resty.Client) error {
 	licensesWrapper := LicensesWrapper{}
 	_, err := client.R().
 		SetResult(&licensesWrapper).
-		Get("/artifactory/api/system/licenses")
+		Get("/artifactory/api/system/license")
 
 	if err != nil {
 		return fmt.Errorf("Failed to check for license. %s", err)


### PR DESCRIPTION
This works for both on-prem and SaaS versions.