### PR TITLE
Upgrade to Go 1.18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       -
         name: Import GPG key
         id: import_gpg

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 )
 
 require (
@@ -26,6 +25,7 @@ require (
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
@@ -44,7 +44,6 @@ require (
 	github.com/hashicorp/terraform-exec v0.15.0 // indirect
 	github.com/hashicorp/terraform-json v0.13.0 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.3.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.3.0 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
@@ -67,9 +66,9 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	go.opencensus.io v0.22.4 // indirect
-	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
+	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
-	golang.org/x/mod v0.5.1 // indirect
+	golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57 // indirect
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect

--- a/go.mod
+++ b/go.mod
@@ -84,4 +84,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-go 1.17
+go 1.18

--- a/go.sum
+++ b/go.sum
@@ -143,7 +143,6 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
@@ -179,7 +178,6 @@ github.com/hashicorp/go-getter v1.5.3 h1:NF5+zOlQegim+w/EUhSLh6QhXHmZMEeHLQzllkQ
 github.com/hashicorp/go-getter v1.5.3/go.mod h1:BrrV/1clo8cCYu6mxvboYg+KutTiFnXjMEgDD8+i7ZI=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v0.15.0 h1:qMuK0wxsoW4D0ddCCYwPSTm4KQv1X1ke3WmPWZ0Mvsk=
 github.com/hashicorp/go-hclog v0.15.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v1.2.0 h1:La19f8d7WIlm4ogzNHB0JGqs5AUDAZ2UfCY4sJXcJdM=
 github.com/hashicorp/go-hclog v1.2.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
@@ -212,8 +210,6 @@ github.com/hashicorp/terraform-plugin-docs v0.5.1 h1:WwrUcamix9x0TqfTw/WGHMRqoTe
 github.com/hashicorp/terraform-plugin-docs v0.5.1/go.mod h1:SQwEgy0/B0UPQ07rNEG1Wpt6E3jvRcCwkVHPNybGgc0=
 github.com/hashicorp/terraform-plugin-go v0.3.0 h1:AJqYzP52JFYl9NABRI7smXI1pNjgR5Q/y2WyVJ/BOZA=
 github.com/hashicorp/terraform-plugin-go v0.3.0/go.mod h1:dFHsQMaTLpON2gWhVWT96fvtlc/MF1vSy3OdMhWBzdM=
-github.com/hashicorp/terraform-plugin-log v0.3.0 h1:NPENNOjaJSVX0f7JJTl4f/2JKRPQ7S2ZN9B4NSqq5kA=
-github.com/hashicorp/terraform-plugin-log v0.3.0/go.mod h1:EjueSP/HjlyFAsDqt+okpCPjkT4NDynAe32AeDC4vps=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0 h1:SuI59MqNjYDrL7EfqHX9V6P/24isgqYx/FdglwVs9bg=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0/go.mod h1:grseeRo9g3yNkYW09iFlV8LG78jTa1ssBgouogQg/RU=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
@@ -275,7 +271,6 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
-github.com/mitchellh/go-testing-interface v1.0.4 h1:ZU1VNC02qyufSZsjjs7+khruk2fKvbQ3TwRV/IBCeFA=
 github.com/mitchellh/go-testing-interface v1.0.4/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
@@ -331,7 +326,6 @@ github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6e
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.2.1/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.8.4/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
@@ -355,8 +349,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 h1:/UOmuWzQfxxo9UtlXMwuQU8CMgg1eZXqTRwkSQJWKOI=
-golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
+golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -388,8 +382,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
-golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
+golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57 h1:LQmS1nU0twXLA96Kt7U9qtHJEbBk3z6Q0V4UXjZkpr4=
+golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180811021610-c39426892332/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -472,7 +466,6 @@ golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
@@ -489,7 +482,6 @@ golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkg/project/provider_test.go
+++ b/pkg/project/provider_test.go
@@ -20,18 +20,29 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func getTestResty(t *testing.T) *resty.Client {
-	if v := os.Getenv("PROJECT_URL"); v == "" {
-		t.Fatal("PROJECT_URL must be set for acceptance tests")
+	var ok bool
+	var projectUrl string
+	if projectUrl, ok = os.LookupEnv("PROJECT_URL"); !ok {
+		if projectUrl, ok = os.LookupEnv("JFROG_URL"); !ok {
+			t.Fatal("PROJECT_URL or JFROG_URL must be set for acceptance tests")
+		}
 	}
-	restyClient, err := buildResty(os.Getenv("PROJECT_URL"))
+	restyClient, err := buildResty(projectUrl)
 	if err != nil {
 		t.Fatal(err)
 	}
-	accessToken := os.Getenv("PROJECT_ACCESS_TOKEN")
+
+	var accessToken string
+	if accessToken, ok = os.LookupEnv("PROJECT_ACCESS_TOKEN"); !ok {
+		if accessToken, ok = os.LookupEnv("JFROG_ACCESS_TOKEN"); !ok {
+			t.Fatal("PROJECT_ACCESS_TOKEN or JFROG_ACCESS_TOKEN must be set for acceptance tests")
+		}
+	}
 	restyClient, err = addAuthToResty(restyClient, accessToken)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	return restyClient
 }
 

--- a/pkg/project/resource_project_repo_test.go
+++ b/pkg/project/resource_project_repo_test.go
@@ -16,8 +16,8 @@ func TestAccProjectRepo(t *testing.T) {
 	resourceName := "project." + name
 	projectKey := strings.ToLower(randSeq(6))
 
-	repo1 := "repo1"
-	repo2 := "repo2"
+	repo1 := fmt.Sprintf("repo%d", randomInt())
+	repo2 := fmt.Sprintf("repo%d", randomInt())
 
 	params := map[string]interface{}{
 		"name":        name,
@@ -100,8 +100,8 @@ func TestAccProjectRepo(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "display_name", name),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
 					resource.TestCheckResourceAttr(resourceName, "repos.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "repos.0", repo1),
-					resource.TestCheckResourceAttr(resourceName, "repos.1", repo2),
+					resource.TestCheckTypeSetElemAttr(resourceName, "repos.*", repo1),
+					resource.TestCheckTypeSetElemAttr(resourceName, "repos.*", repo2),
 				),
 			},
 			{

--- a/pkg/project/resource_project_test.go
+++ b/pkg/project/resource_project_test.go
@@ -170,8 +170,8 @@ func TestAccProject(t *testing.T) {
 	email2 := username2 + "@tempurl.org"
 	group1 := "group1"
 	group2 := "group2"
-	repo1 := "repo1"
-	repo2 := "repo2"
+	repo1 := fmt.Sprintf("repo%d", randomInt())
+	repo2 := fmt.Sprintf("repo%d", randomInt())
 
 	params := map[string]interface{}{
 		"max_storage_in_gibibytes":   rand.Intn(100),
@@ -295,8 +295,8 @@ func TestAccProject(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "group.1.roles.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "group.1.roles.0", "release manager"),
 					resource.TestCheckResourceAttr(resourceName, "repos.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "repos.0", repo1),
-					resource.TestCheckResourceAttr(resourceName, "repos.1", repo2),
+					resource.TestCheckTypeSetElemAttr(resourceName, "repos.*", repo1),
+					resource.TestCheckTypeSetElemAttr(resourceName, "repos.*", repo2),
 				),
 			},
 		},

--- a/pkg/project/set.go
+++ b/pkg/project/set.go
@@ -1,0 +1,54 @@
+package project
+
+import (
+	"log"
+)
+
+type Set[T Equatable] []T
+
+func SetFromSlice[T Equatable](values []T) Set[T] {
+	set := make(Set[T], 0)
+	set = append(set, values...)
+	log.Printf("[TRACE] set: %v", set)
+	return set
+}
+
+func (s Set[T]) Contains(b T) bool {
+	log.Printf("[DEBUG] Set.Contains")
+	log.Printf("[TRACE] s: %+v", s)
+	log.Printf("[TRACE] b: %+v", b)
+
+	for _, a := range s {
+		log.Printf("[TRACE] a: %+v\n", a)
+		log.Printf("[TRACE] a.Equals(b): %+v", a.Equals(b))
+		if a.Equals(b) {
+			return true
+		}
+	}
+	return false
+}
+
+// Intersection returns a Set containing all the common items between both Sets.
+// Example: [1, 2, 3].Intersection([2, 3, 4]) = [2, 3].
+func (s Set[T]) Intersection(other Set[T]) Set[T] {
+	intersection := make(Set[T], 0)
+	for _, item := range s {
+		if other.Contains(item) {
+			intersection = append(intersection, item)
+		}
+	}
+	return intersection
+}
+
+// Difference returns a Set containing all the items not contained in the other set.
+// Note this is "unidirectional", and the result is _only_ the elements in A that are not in B.
+// Example: [1, 2, 3].Difference([2, 3, 4]) = [1].
+func (s Set[T]) Difference(other Set[T]) Set[T] {
+	diff := make(Set[T], 0)
+	for _, item := range s {
+		if !other.Contains(item) {
+			diff = append(diff, item)
+		}
+	}
+	return diff
+}

--- a/pkg/project/util.go
+++ b/pkg/project/util.go
@@ -2,7 +2,6 @@ package project
 
 import (
 	"bytes"
-	"log"
 	"math"
 	"net/http"
 	"os"
@@ -140,46 +139,8 @@ type Identifiable interface {
 
 type Equatable interface {
 	Identifiable
-	Equals(other Identifiable) bool
+	Equals(other Equatable) bool
 }
-
-func contains(as []Equatable, b Equatable) bool {
-	log.Printf("[DEBUG] contains")
-	log.Printf("[TRACE] as: %+v\n", as)
-	log.Printf("[TRACE] b: %+v\n", b)
-
-	for _, a := range as {
-		log.Printf("[TRACE] a: %+v\n", a)
-		log.Printf("[TRACE] a.Equals(b): %+v\n", a.Equals(b))
-		if a.Equals(b) {
-			return true
-		}
-	}
-	return false
-}
-
-var apply = func(predicate func(bs []Equatable, a Equatable) bool) func(as []Equatable, bs []Equatable) []Equatable {
-	return func(as []Equatable, bs []Equatable) []Equatable {
-		var results []Equatable
-
-		// Not the most efficient way to determine the slices intersection but this suffices for the small-ish number of items
-		for _, a := range as {
-			if predicate(bs, a) {
-				results = append(results, a)
-			}
-		}
-
-		return results
-	}
-}
-
-var intersection = apply(func(bs []Equatable, a Equatable) bool {
-	return contains(bs, a)
-})
-
-var difference = apply(func(bs []Equatable, a Equatable) bool {
-	return !contains(bs, a)
-})
 
 var getBoolEnvVar = func(key string, fallback bool) bool {
 	value, exists := os.LookupEnv(key)

--- a/pkg/project/util_test.go
+++ b/pkg/project/util_test.go
@@ -141,10 +141,10 @@ func randSeq(n int) string {
 	return string(b)
 }
 
-var randomInt = func() func() int {
+func randomInt() int {
 	rand.Seed(time.Now().UnixNano())
-	return rand.Int
-}()
+	return rand.Int()
+}
 
 func randBool() bool {
 	return randomInt()%2 == 0


### PR DESCRIPTION
- Create own `Set` type for `Difference()` and `Intersection()` funcs
- Cleanup/replace deprecated code due to new `Set` and generics
- Update `getTestResty()` to use either `PROJECT_*` or `JFROG_*` env vars