### PR TITLE
Revert "Merge pull request #48 from apr-1985/project_key_test_update"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.7.0
 	github.com/hashicorp/terraform-plugin-log v0.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
-	github.com/jfrog/terraform-provider-shared v1.5.0
+	github.com/jfrog/terraform-provider-shared v1.4.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/terraform-provider-shared v1.5.0 h1:nuLMTzO5tigJjp7TGgfHSthw1BfigCrPq8+tOSBdbYo=
-github.com/jfrog/terraform-provider-shared v1.5.0/go.mod h1:8Ah3LHk0irA14Mq3t8uaYax+V+l9M4sKZXFcqoPtZkI=
+github.com/jfrog/terraform-provider-shared v1.4.0 h1:OVf0FxlTuDu5XlJM2IEvk+Sju4R/IP9mv5fAAB78GFE=
+github.com/jfrog/terraform-provider-shared v1.4.0/go.mod h1:8Ah3LHk0irA14Mq3t8uaYax+V+l9M4sKZXFcqoPtZkI=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=

--- a/pkg/project/resource_project_test.go
+++ b/pkg/project/resource_project_test.go
@@ -49,7 +49,7 @@ func makeInvalidProjectKeyTestCase(invalidProjectKey string, t *testing.T) (*tes
 		Steps: []resource.TestStep{
 			{
 				Config:      project,
-				ExpectError: regexp.MustCompile(`.*key must be 3 - 25 lowercase alphanumeric characters.*`),
+				ExpectError: regexp.MustCompile(`.*key must be 3 - 10 lowercase alphanumeric characters.*`),
 			},
 		},
 	}
@@ -68,7 +68,7 @@ func TestAccProjectInvalidProjectKey(t *testing.T) {
 		},
 		{
 			Name:  "TooLong",
-			Value: strings.ToLower(randSeq(26)),
+			Value: strings.ToLower(randSeq(11)),
 		},
 		{
 			Name:  "HasUppercase",

--- a/sample.tf
+++ b/sample.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     project = {
       source  = "registry.terraform.io/jfrog/project"
-      version = "1.1.4"
+      version = "1.1.1"
     }
   }
 }


### PR DESCRIPTION
Revert https://github.com/jfrog/terraform-provider-project/pull/48

`ProjectKey` validator was changed to expand string length limit based on misunderstanding on how it works in the provider.

There's no change to the size limit handling in Artifactory, thus the change needs to be reverted.