### PR TITLE
Ignore unassigning (non-existent) repository error when destroying project resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.8 (Sep 28, 2022)
+
+BUG FIXES:
+
+* resource/project: Ignore unassigning (non-existent) repository error when destroying project resource. PR: [#57](https://github.com/jfrog/terraform-provider-project/pull/57)
+
 ## 1.1.7 (Sep 8, 2022). Tested on Artifactory 7.41.12 and Xray 3.55.2
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.8 (Sep 28, 2022)
+## 1.1.8 (Sep 28, 2022). Tested on Artifactory 7.41.13 and Xray 3.57.6
 
 BUG FIXES:
 

--- a/pkg/project/resource_project.go
+++ b/pkg/project/resource_project.go
@@ -42,10 +42,6 @@ func (p Project) Id() string {
 const projectsUrl = "/access/api/v1/projects"
 const projectUrl = projectsUrl + "/{projectKey}"
 
-func verifyProject(id string, request *resty.Request) (*resty.Response, error) {
-	return request.Head(projectsUrl + id)
-}
-
 var customRoleTypeRegex = regexp.MustCompile(fmt.Sprintf("^%s$", customRoleType))
 
 func projectResource() *schema.Resource {

--- a/pkg/project/resource_project_test.go
+++ b/pkg/project/resource_project_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/jfrog/terraform-provider-shared/test"
 )
 
+func verifyProject(id string, request *resty.Request) (*resty.Response, error) {
+	return request.Head(projectsUrl + id)
+}
+
 func makeInvalidProjectKeyTestCase(invalidProjectKey string, t *testing.T) (*testing.T, resource.TestCase) {
 	name := fmt.Sprintf("tftestprojects%s", randSeq(10))
 	resourceName := fmt.Sprintf("project.%s", name)


### PR DESCRIPTION
Fixes #56 

* Skip error when unassigning repo from project