### PR TITLE
Fix typo in project resource documentation

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -20,7 +20,7 @@ description: |-
   }
   ```
 
-  ~>We strongly recommend using the 'preject_repository' resource instead to manage the list of repositories.
+  ~>We strongly recommend using the 'project_repository' resource instead to manage the list of repositories.
 ---
 
 # project (Resource)
@@ -44,7 +44,7 @@ resource "artifactory_local_maven_repository" "my_maven_releases" {
 }
 ```
 
-~>We strongly recommend using the 'preject_repository' resource instead to manage the list of repositories.
+~>We strongly recommend using the 'project_repository' resource instead to manage the list of repositories.
 
 ## Example Usage
 


### PR DESCRIPTION
I have identified and fixed a typo in the documentation file project.md. This file appears to be autogenerated by the terraform-plugin-docs plugin, but I wasn't able to determine the exact source of the typo from the code base. As a result, I made a direct modification to the markdown file.

If this is not the correct way to address this issue and the typo should instead be fixed from the original source that generates the file, I fully understand. Please feel free to close this PR, and open a new one with the correct fix. 