### PR TITLE
Ensure create/update funcs return early if errored for project_environment resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.9.3 (December 19, 2024)
+
+BUG FIXES:
+
+* resource/project_environment: Fix error handling during creation/update where state shouldn't be stored/updated when there is API error. Issue: [#184](https://github.com/jfrog/terraform-provider-project/issues/184) PR: [#188](https://github.com/jfrog/terraform-provider-project/pull/188)
+
 ## 1.9.2 (November 26, 2024). Tested on Artifactory 7.98.9 with Terraform 1.9.8 and OpenTofu 1.8.6
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.9.3 (December 19, 2024)
+## 1.9.3 (December 19, 2024). Tested on Artifactory 7.98.11 with Terraform 1.10.3 and OpenTofu 1.8.7
 
 BUG FIXES:
 

--- a/pkg/project/resource/resource_project_environment.go
+++ b/pkg/project/resource/resource_project_environment.go
@@ -3,7 +3,6 @@ package project
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"regexp"
 	"strings"
 
@@ -114,9 +113,11 @@ func (r *ProjectEnvironmentResource) Create(ctx context.Context, req resource.Cr
 		Post(ProjectEnvironmentUrl)
 	if err != nil {
 		utilfw.UnableToCreateResourceError(resp, err.Error())
+		return
 	}
 	if response.IsError() {
 		utilfw.UnableToCreateResourceError(resp, projectError.String())
+		return
 	}
 
 	plan.ID = types.StringValue(environment.Name)
@@ -146,10 +147,6 @@ func (r *ProjectEnvironmentResource) Read(ctx context.Context, req resource.Read
 		Get(ProjectEnvironmentUrl)
 	if err != nil {
 		utilfw.UnableToRefreshResourceError(resp, err.Error())
-		return
-	}
-	if response.StatusCode() == http.StatusNotFound {
-		resp.State.RemoveResource(ctx)
 		return
 	}
 	if response.IsError() {
@@ -211,9 +208,11 @@ func (r *ProjectEnvironmentResource) Update(ctx context.Context, req resource.Up
 		Post(ProjectEnvironmentUrl + "/{environmentName}/rename")
 	if err != nil {
 		utilfw.UnableToUpdateResourceError(resp, err.Error())
+		return
 	}
 	if response.IsError() {
 		utilfw.UnableToUpdateResourceError(resp, projectError.String())
+		return
 	}
 
 	plan.ID = types.StringValue(environmentUpdate.NewName)


### PR DESCRIPTION
For #184 