### PR TITLE
fix: add mutex to remove race conditions for repository sharing

### DIFF
--- a/pkg/project/resource/resource_project_share_repository.go
+++ b/pkg/project/resource/resource_project_share_repository.go
@@ -112,6 +112,10 @@ func (r *ProjectShareRepositoryResource) Configure(ctx context.Context, req reso
 func (r *ProjectShareRepositoryResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	go util.SendUsageResourceCreate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
 
+	lockName := "share"
+	GlobalMutex.Lock(lockName)
+	defer GlobalMutex.Unlock(lockName)
+
 	var plan ProjectShareRepositoryResourceModel
 
 	// Read Terraform plan data into the model
@@ -203,6 +207,10 @@ func (r *ProjectShareRepositoryResource) Update(ctx context.Context, req resourc
 
 func (r *ProjectShareRepositoryResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	go util.SendUsageResourceDelete(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	lockName := "share"
+	GlobalMutex.Lock(lockName)
+	defer GlobalMutex.Unlock(lockName)
 
 	var state ProjectShareRepositoryResourceModel
 

--- a/pkg/project/resource/util.go
+++ b/pkg/project/resource/util.go
@@ -3,6 +3,7 @@ package project
 import (
 	"fmt"
 	"regexp"
+	"sync"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/jfrog/terraform-provider-shared/util"
@@ -53,4 +54,44 @@ type ProjectRepositoryStatusAPIModel struct {
 	SharedWithAllProjects bool     `json:"shared_with_all_projects"`
 	SharedReadOnly        bool     `json:"shared_read_only"`
 	AssignedTo            string   `json:"assigned_to"`
+}
+
+var GlobalMutex = newMutexKV()
+
+// mutexKV is a simple key/value store for arbitrary mutexes. It can be used to
+// serialize changes across arbitrary collaborators that share knowledge of the
+// keys they must serialize on.
+type mutexKV struct {
+	lock  sync.Mutex
+	store map[string]*sync.Mutex
+}
+
+// Locks the mutex for the given key. Caller is responsible for calling Unlock
+// for the same key
+func (m *mutexKV) Lock(key string) {
+	m.get(key).Lock()
+}
+
+// Unlock the mutex for the given key. Caller must have called Lock for the same key first
+func (m *mutexKV) Unlock(key string) {
+	m.get(key).Unlock()
+}
+
+// Returns a mutex for the given key, no guarantee of its lock status
+func (m *mutexKV) get(key string) *sync.Mutex {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	mutex, ok := m.store[key]
+	if !ok {
+		mutex = &sync.Mutex{}
+		m.store[key] = mutex
+	}
+	return mutex
+}
+
+// Returns a properly initialized MutexKV
+func newMutexKV() *mutexKV {
+	return &mutexKV{
+		store: make(map[string]*sync.Mutex),
+	}
 }


### PR DESCRIPTION
I was trying to create multiple repository shares within a artifactory project that share the same repository. To ease the configuration, i tried adding a `for_each` sequence, but unfortunately, it wasn't working.
With the current provider (v1.9.3) i'm getting multiple bad request errors and no valid state. 

I found out that the problem was that multiple api calls for the same repository were causing the issue. To fix this, I added a mutex to the create and deletion functions of the resource to stop concurrency.
The mutex is defined as global to use it for future reference if necessary.