### PR TITLE
Fix goreleaser build failure for unsupported windows/arm target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,8 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
+    - goos: windows
+      goarch: arm
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
## Summary
- Go no longer supports the `windows/arm` (32-bit ARM) GOOS/GOARCH pair, causing goreleaser release to fail with: `go: unsupported GOOS/GOARCH pair windows/arm` (`target=windows_arm_6`)
- Adds `windows/arm` to the `ignore` list in `.goreleaser.yml` to skip this unsupported build target

## Test plan
- [ ] Verify goreleaser release completes successfully without the `windows/arm` build error

Made with [Cursor](https://cursor.com)