### PR TITLE
fix(project): raise display_name max length from 32 to 128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.9.8 (Jul 24, 2026)
+
+BUG FIXES:
+
+* resource/project: Fixed the `display_name` attribute rejecting values longer than 32 characters. The JFrog platform accepts display names up to 128 characters (verified against the Access API), but the provider imposed a stricter client-side limit of 32, preventing management of projects that are valid in the UI/API. The upper bound is now 128. Issue: [#236](https://github.com/jfrog/terraform-provider-project/issues/236)
+
 ## 1.9.7 (July 17, 2026). Tested on Artifactory 7.146.28 with Terraform 1.15.8 and OpenTofu 1.12.4
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.9.8 (Jul 24, 2026)
+## 1.9.8 (Jul 24, 2026). Tested on Artifactory 7.146.29 with Terraform 1.15.8 and OpenTofu 1.12.5
 
 BUG FIXES:
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -70,7 +70,7 @@ resource "project" "myproject" {
 
 ### Required
 
-- `display_name` (String) Also known as project name on the UI
+- `display_name` (String) Also known as project name on the UI. Length must be between 1 and 128 characters.
 - `key` (String) The Project Key is added as a prefix to resources created within a Project. This field is mandatory and supports only 2 - 32 lowercase alphanumeric and hyphen characters. Must begin with a letter. For example: `us1a-test`.
 
 ### Optional

--- a/pkg/project/resource/resource_project.go
+++ b/pkg/project/resource/resource_project.go
@@ -428,9 +428,9 @@ var schemaV1 = schema.Schema{
 		"display_name": schema.StringAttribute{
 			Required: true,
 			Validators: []validator.String{
-				stringvalidator.LengthBetween(1, 32),
+				stringvalidator.LengthBetween(1, 128),
 			},
-			Description: "Also known as project name on the UI",
+			Description: "Also known as project name on the UI. Length must be between 1 and 128 characters.",
 		},
 		"description": schema.StringAttribute{
 			Optional: true,

--- a/pkg/project/resource/resource_project_test.go
+++ b/pkg/project/resource/resource_project_test.go
@@ -434,6 +434,40 @@ func testProjectConfig(name, key string) string {
 	`, params)
 }
 
+// testProjectConfigWithDisplayName builds a project config where display_name is
+// set independently from the Terraform resource label, so display_name values
+// that are invalid or longer than the label can be exercised.
+func testProjectConfigWithDisplayName(name, key, displayName string) string {
+	params := map[string]interface{}{
+		"max_storage_in_gibibytes":   getRandomMaxStorageSize(),
+		"block_deployments_on_limit": testutil.RandBool(),
+		"email_notification":         testutil.RandBool(),
+		"manage_members":             testutil.RandBool(),
+		"manage_resources":           testutil.RandBool(),
+		"manage_remote_repository":   testutil.RandBool(),
+		"index_resources":            testutil.RandBool(),
+		"name":                       name,
+		"project_key":                key,
+		"display_name":               displayName,
+	}
+	return util.ExecuteTemplate("TestAccProjects", `
+		resource "project" "{{ .name }}" {
+			key = "{{ .project_key }}"
+			display_name = "{{ .display_name }}"
+			description = "test description"
+			admin_privileges {
+				manage_members = {{ .manage_members }}
+				manage_resources = {{ .manage_resources }}
+				manage_remote_repository = {{ .manage_remote_repository }}
+				index_resources = {{ .index_resources }}
+			}
+			max_storage_in_gibibytes = {{ .max_storage_in_gibibytes }}
+			block_deployments_on_limit = {{ .block_deployments_on_limit }}
+			email_notification = {{ .email_notification }}
+		}
+	`, params)
+}
+
 func TestAccProject_MultiProjectsWithRepos(t *testing.T) {
 	numberOfProjects := 50
 	config := testProjectConfigMultiProjectsWithRepos(numberOfProjects)
@@ -638,9 +672,11 @@ func makeInvalidMaxStorageTestCase(invalidMaxStorage int64, errorRegex string, t
 }
 
 func TestAccProject_InvalidDisplayName(t *testing.T) {
-	name := fmt.Sprintf("invalidtestprojects%s", acctest.RandSeq(20))
+	name := fmt.Sprintf("invalidtestprojects%s", acctest.RandSeq(8))
 	resourceName := fmt.Sprintf("project.%s", name)
-	project := testProjectConfig(name, strings.ToLower(acctest.RandSeq(6)))
+	// display_name of 129 chars exceeds the JFrog platform maximum of 128.
+	displayName := acctest.RandSeq(129)
+	project := testProjectConfigWithDisplayName(name, strings.ToLower(acctest.RandSeq(6)), displayName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -649,7 +685,34 @@ func TestAccProject_InvalidDisplayName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      project,
-				ExpectError: regexp.MustCompile(`.*Attribute display_name string length must be between 1 and 32.*`),
+				ExpectError: regexp.MustCompile(`.*Attribute display_name string length must be between 1 and 128.*`),
+			},
+		},
+	})
+}
+
+func TestAccProject_LongDisplayName(t *testing.T) {
+	name := fmt.Sprintf("testprojects%s", acctest.RandSeq(8))
+	resourceName := fmt.Sprintf("project.%s", name)
+	// display_name longer than the old 32-char limit but within the platform maximum of 128.
+	displayName := acctest.RandSeq(100)
+	project := testProjectConfigWithDisplayName(name, strings.ToLower(acctest.RandSeq(6)), displayName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		CheckDestroy:             acctest.VerifyDeleted(resourceName, verifyProject),
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: project,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "display_name", displayName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/pkg/project/resource/resource_project_test.go
+++ b/pkg/project/resource/resource_project_test.go
@@ -713,6 +713,12 @@ func TestAccProject_LongDisplayName(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"use_project_role_resource",
+					"use_project_user_resource",
+					"use_project_group_resource",
+					"use_project_repository_resource",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Fixes #236. The `project` resource rejected `display_name` values longer than 32 characters, but the JFrog platform accepts up to **128**. The provider's client-side validation was stricter than the API, so projects that are valid in the UI/API could not be created or managed via Terraform.

## Root cause

`pkg/project/resource/resource_project.go` hardcoded:

```go
stringvalidator.LengthBetween(1, 32)
```

The OpenAPI spec declares no `max_length` for `display_name`, and the real platform limit is 128.

## Verification

Probed the Access API (`POST /access/api/v1/projects`) directly:

| display_name length | result |
|---|---|
| 32, 64, 100, 127, **128** | `201 Created` |
| **129**, 256 | `400 — "Name too long (must be 128 char max)"` |

A real project already on the platform has an 84-character display name — beyond the old 32 cap — confirming the restriction blocked valid data.

## Changes

- Raise validator upper bound to `LengthBetween(1, 128)` and document the limit in the schema description.
- Regenerate the corresponding line in `docs/resources/project.md`.
- Rework `TestAccProject_InvalidDisplayName` to assert the `1 and 128` bound, using a `display_name` decoupled from the Terraform resource label (new `testProjectConfigWithDisplayName` helper).
- Add `TestAccProject_LongDisplayName` — a positive test creating a 100-char display name, with an import-verify step.
- Add CHANGELOG entry.

## Notes

- There is no `project` data source, so no data-source change is needed.
- Bound chosen to match the confirmed platform maximum (128) rather than simply removing the cap, so users still get a fast client-side error instead of a round-trip 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
