### PR TITLE
feat(namespacing): add jfrog_ namespaced resources with deprecated aliases for legacy names (#210, phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ tfc-testing/.terraform
 tfc-testing/terraform.d
 tfc-testing/.terraform.lock.hcl
 .DS_Store
+
+# Local environment / credentials
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.10.0 (July 24, 2026)
+
+FEATURES:
+
+* All resources are now available under the `jfrog_` namespace: `jfrog_project`, `jfrog_project_environment`, `jfrog_project_group`, `jfrog_project_repository`, `jfrog_project_role`, `jfrog_project_share_repository`, `jfrog_project_share_repository_with_all`, and `jfrog_project_user`. This makes it clear the resources belong to the JFrog Platform and conforms to the `<provider>_<resource>` naming convention expected by the ecosystem (including Crossplane Upjet). To use the namespaced resources, configure the provider under the `jfrog` local name, e.g. `required_providers { jfrog = { source = "jfrog/project" } }`. See the "Migrating to the `jfrog_` namespace" guide for details. Issue: [#210](https://github.com/jfrog/terraform-provider-project/issues/210) PR: [#235](https://github.com/jfrog/terraform-provider-project/pull/235)
+
+DEPRECATIONS:
+
+* The un-namespaced resource names (`project`, `project_environment`, `project_group`, `project_repository`, `project_role`, `project_share_repository`, `project_share_repository_with_all`, `project_user`) are deprecated in favor of their `jfrog_`-namespaced equivalents. They continue to work in this release (using the `project` local name) but will be removed in the next major release. Issue: [#210](https://github.com/jfrog/terraform-provider-project/issues/210) PR: [#235](https://github.com/jfrog/terraform-provider-project/pull/235)
+
 ## 1.9.7 (July 17, 2026). Tested on Artifactory 7.146.28 with Terraform 1.15.8 and OpenTofu 1.12.4
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.10.0 (July 24, 2026)
+## 1.10.0 (July 24, 2026). Tested on Artifactory 7.146.29 with Terraform 1.15.8 and OpenTofu 1.12.5
 
 FEATURES:
 

--- a/examples/full.tf
+++ b/examples/full.tf
@@ -5,9 +5,9 @@ terraform {
       source  = "registry.terraform.io/jfrog/artifactory"
       version = "10.3.0"
     }
-    project = {
+    jfrog = {
       source  = "registry.terraform.io/jfrog/project"
-      version = "1.5.0"
+      version = "1.10.0"
     }
   }
 }
@@ -21,7 +21,7 @@ provider "artifactory" {
   url = "${var.artifactory_url}"
 }
 
-provider "project" {
+provider "jfrog" {
   url = "${var.artifactory_url}"
 }
 
@@ -78,7 +78,7 @@ resource "artifactory_remote_npm_repository" "npm-remote" {
 
 # Project resources
 
-resource "project" "myproject" {
+resource "jfrog_project" "myproject" {
   key = "myproj"
   display_name = "My Project"
   description  = "My Project"
@@ -93,57 +93,57 @@ resource "project" "myproject" {
   email_notification         = true
 }
 
-resource "project_user" "user1" {
-  project_key = project.myproject.key
+resource "jfrog_project_user" "user1" {
+  project_key = jfrog_project.myproject.key
   name        = "user1"
   roles       = ["developer","project admin"]
 }
 
-resource "project_user" "user2" {
-  project_key = project.myproject.key
+resource "jfrog_project_user" "user2" {
+  project_key = jfrog_project.myproject.key
   name        = "user2"
   roles       = ["developer"]
 }
 
-resource "project_group" "qa" {
-  project_key = project.myproject.key
+resource "jfrog_project_group" "qa" {
+  project_key = jfrog_project.myproject.key
   name        = "qa"
   roles       = ["qa"]
 }
 
-resource "project_group" "release" {
-  project_key = project.myproject.key
+resource "jfrog_project_group" "release" {
+  project_key = jfrog_project.myproject.key
   name        = "release"
   roles       = ["release manager"]
 }
 
-resource "project_role" "qa" {
-  project_key  = project.myproject.key
+resource "jfrog_project_role" "qa" {
+  project_key  = jfrog_project.myproject.key
   name         = "qa"
   type         = "CUSTOM"
   environments = ["DEV"]
   actions      = var.qa_roles
 }
 
-resource "project_role" "devop" {
-  project_key  = project.myproject.key
+resource "jfrog_project_role" "devop" {
+  project_key  = jfrog_project.myproject.key
   name         = "devop"
   type         = "CUSTOM"
   environments = ["DEV", "PROD"]
   actions      = var.devop_roles
 }
 
-resource "project_repository" "docker-local" {
-  project_key = project.myproject.key
+resource "jfrog_project_repository" "docker-local" {
+  project_key = jfrog_project.myproject.key
   key         = "docker-local"
 }
 
-resource "project_repository" "npm-local" {
-  project_key = project.myproject.key
+resource "jfrog_project_repository" "npm-local" {
+  project_key = jfrog_project.myproject.key
   key         = "npm-local"
 }
 
-resource "project_environment" "myenv" {
-  project_key = project.myproj.key
+resource "jfrog_project_environment" "myenv" {
+  project_key = jfrog_project.myproject.key
   name        = "myenv"
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,4 +1,4 @@
-provider "project" {
+provider "jfrog" {
   url = "${var.artifactory_url}"
   access_token = "${var.artifactory_access_token}"
 }

--- a/examples/resources/jfrog_project/import.sh
+++ b/examples/resources/jfrog_project/import.sh
@@ -1,0 +1,1 @@
+terraform import jfrog_project.myproject myproj

--- a/examples/resources/jfrog_project/resource.tf
+++ b/examples/resources/jfrog_project/resource.tf
@@ -1,0 +1,14 @@
+resource "jfrog_project" "myproject" {
+  key = "myproj"
+  display_name = "My Project"
+  description  = "My Project"
+  admin_privileges {
+    manage_members           = true
+    manage_resources         = true
+    manage_remote_repository = true
+    index_resources          = true
+  }
+  max_storage_in_gibibytes   = 10
+  block_deployments_on_limit = false
+  email_notification         = true
+}

--- a/examples/resources/jfrog_project_environment/import.sh
+++ b/examples/resources/jfrog_project_environment/import.sh
@@ -1,0 +1,1 @@
+terraform import jfrog_project_environment.myenv project_key:environment_name

--- a/examples/resources/jfrog_project_environment/resource.tf
+++ b/examples/resources/jfrog_project_environment/resource.tf
@@ -1,0 +1,4 @@
+resource "jfrog_project_environment" "myenv" {
+  name        = "myenv"
+  project_key = "myproj"
+}

--- a/examples/resources/jfrog_project_group/import.sh
+++ b/examples/resources/jfrog_project_group/import.sh
@@ -1,0 +1,1 @@
+terraform import jfrog_project_group.mygroup project_key:groupname

--- a/examples/resources/jfrog_project_group/resource.tf
+++ b/examples/resources/jfrog_project_group/resource.tf
@@ -1,0 +1,5 @@
+resource "jfrog_project_group" "mygroup" {
+  project_key = "myproj"
+  name        = "mygroup"
+  roles       = ["Viewer"]
+}

--- a/examples/resources/jfrog_project_repository/import.sh
+++ b/examples/resources/jfrog_project_repository/import.sh
@@ -1,0 +1,1 @@
+terraform import jfrog_project_repository.myprojectrepo project_key:repository_key

--- a/examples/resources/jfrog_project_repository/resource.tf
+++ b/examples/resources/jfrog_project_repository/resource.tf
@@ -1,0 +1,4 @@
+resource "jfrog_project_repository" "myprojectrepo" {
+  project_key = "myproj"
+  key         = "my-generic-local"
+}

--- a/examples/resources/jfrog_project_role/import.sh
+++ b/examples/resources/jfrog_project_role/import.sh
@@ -1,0 +1,1 @@
+terraform import jfrog_project_role.myrole project_key:role_name

--- a/examples/resources/jfrog_project_role/resource.tf
+++ b/examples/resources/jfrog_project_role/resource.tf
@@ -1,0 +1,8 @@
+resource "jfrog_project_role" "myrole" {
+  name        = "myrole"
+  type        = "CUSTOM"
+  project_key = jfrog_project.myproject.key
+
+  environments = ["DEV"]
+  actions      = ["READ_REPOSITORY", "ANNOTATE_REPOSITORY"]
+}

--- a/examples/resources/jfrog_project_share_repository/import.sh
+++ b/examples/resources/jfrog_project_share_repository/import.sh
@@ -1,0 +1,1 @@
+terraform import jfrog_project_share_repository.myprojectsharerepo repo_key:project_key

--- a/examples/resources/jfrog_project_share_repository/resource.tf
+++ b/examples/resources/jfrog_project_share_repository/resource.tf
@@ -1,0 +1,21 @@
+# Share repository with a project
+resource "jfrog_project_share_repository" "myprojectsharerepo" {
+  repo_key           = "myrepo-generic-local"
+  target_project_key = "myproj"
+}
+
+# Share repository with multiple projects
+resource "jfrog_project_share_repository" "share_repo" {
+  count = 3
+
+  repo_key = artifactory_local_generic_repository.repo.key
+  target_project_key = element(
+    [
+      jfrog_project.project_name_1.key,
+      jfrog_project.project_name_2.key,
+      jfrog_project.project_name_3.key
+    ],
+    count.index
+  )
+  read_only = true
+}

--- a/examples/resources/jfrog_project_share_repository_with_all/import.sh
+++ b/examples/resources/jfrog_project_share_repository_with_all/import.sh
@@ -1,0 +1,1 @@
+terraform import jfrog_project_share_repository_with_all.myprojectsharerepo repo_key

--- a/examples/resources/jfrog_project_share_repository_with_all/resource.tf
+++ b/examples/resources/jfrog_project_share_repository_with_all/resource.tf
@@ -1,0 +1,3 @@
+resource "jfrog_project_share_repository_with_all" "myprojectsharerepo" {
+  repo_key = "myrepo-generic-local"
+}

--- a/examples/resources/jfrog_project_user/import.sh
+++ b/examples/resources/jfrog_project_user/import.sh
@@ -1,0 +1,1 @@
+terraform import jfrog_project_user.myuser project_key:username

--- a/examples/resources/jfrog_project_user/resource.tf
+++ b/examples/resources/jfrog_project_user/resource.tf
@@ -1,0 +1,5 @@
+resource "jfrog_project_user" "myuser" {
+  project_key = "myproj"
+  name        = "myuser"
+  roles       = ["Viewer"]
+}

--- a/pkg/project/acctest/test.go
+++ b/pkg/project/acctest/test.go
@@ -33,8 +33,14 @@ var ProtoV6ProviderFactories map[string]func() (tfprotov6.ProviderServer, error)
 func init() {
 	Provider = project.NewProvider()()
 
+	// The provider is registered under both local names so acceptance tests can
+	// reference resources by their legacy un-namespaced type (routes to local
+	// name "project", e.g. `project`, `project_user`) and by their new
+	// `jfrog_`-namespaced type (routes to local name "jfrog", e.g.
+	// `jfrog_project`). See issue #210.
 	ProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
 		"project": providerserver.NewProtocol6WithError(Provider),
+		"jfrog":   providerserver.NewProtocol6WithError(Provider),
 	}
 }
 

--- a/pkg/project/provider.go
+++ b/pkg/project/provider.go
@@ -191,6 +191,7 @@ func (p *ProjectProvider) Configure(ctx context.Context, req provider.ConfigureR
 // Resources satisfies the provider.Provider interface for ProjectProvider.
 func (p *ProjectProvider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		// Namespaced resources (primary, `jfrog_` prefix).
 		project.NewProjectResource,
 		project.NewProjectEnvironmentResource,
 		project.NewProjectGroupResource,
@@ -199,6 +200,17 @@ func (p *ProjectProvider) Resources(ctx context.Context) []func() resource.Resou
 		project.NewProjectShareRepositoryResource,
 		project.NewProjectShareRepositoryWithAllResource,
 		project.NewProjectUserResource,
+		// Deprecated, un-namespaced aliases. These are kept for backward
+		// compatibility (Phase 1 of https://github.com/jfrog/terraform-provider-project/issues/210)
+		// and will be removed in the next major release.
+		project.NewProjectResourceDeprecated,
+		project.NewProjectEnvironmentResourceDeprecated,
+		project.NewProjectGroupResourceDeprecated,
+		project.NewProjectRepositoryResourceDeprecated,
+		project.NewProjectRoleResourceDeprecated,
+		project.NewProjectShareRepositoryResourceDeprecated,
+		project.NewProjectShareRepositoryWithAllResourceDeprecated,
+		project.NewProjectUserResourceDeprecated,
 	}
 }
 

--- a/pkg/project/provider_test.go
+++ b/pkg/project/provider_test.go
@@ -1,0 +1,86 @@
+package project_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/jfrog/terraform-provider-project/pkg/project"
+)
+
+// TestProvider_resourceNamespacing verifies Phase 1 of issue #210: every
+// resource is exposed under the new `jfrog_` namespaced name, and the legacy
+// un-namespaced name is still registered as a deprecated alias pointing at the
+// same implementation.
+func TestProvider_resourceNamespacing(t *testing.T) {
+	ctx := context.Background()
+
+	p, ok := project.NewProvider()().(interface {
+		Resources(context.Context) []func() resource.Resource
+	})
+	if !ok {
+		t.Fatal("provider does not expose Resources")
+	}
+
+	// Expected legacy name -> namespaced name pairs.
+	expected := map[string]string{
+		"project":                           "jfrog_project",
+		"project_environment":               "jfrog_project_environment",
+		"project_group":                     "jfrog_project_group",
+		"project_repository":                "jfrog_project_repository",
+		"project_role":                      "jfrog_project_role",
+		"project_share_repository":          "jfrog_project_share_repository",
+		"project_share_repository_with_all": "jfrog_project_share_repository_with_all",
+		"project_user":                      "jfrog_project_user",
+	}
+
+	type meta struct {
+		deprecated bool
+	}
+	seen := map[string]meta{}
+
+	for _, rf := range p.Resources(ctx) {
+		res := rf()
+
+		var metaResp resource.MetadataResponse
+		res.Metadata(ctx, resource.MetadataRequest{ProviderTypeName: "project"}, &metaResp)
+
+		var schemaResp resource.SchemaResponse
+		res.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+
+		if _, dup := seen[metaResp.TypeName]; dup {
+			t.Fatalf("resource type name %q registered more than once", metaResp.TypeName)
+		}
+		seen[metaResp.TypeName] = meta{deprecated: schemaResp.Schema.GetDeprecationMessage() != ""}
+	}
+
+	for legacy, namespaced := range expected {
+		ns, ok := seen[namespaced]
+		if !ok {
+			t.Errorf("expected namespaced resource %q to be registered", namespaced)
+		} else if ns.deprecated {
+			t.Errorf("namespaced resource %q must NOT be deprecated", namespaced)
+		}
+
+		lg, ok := seen[legacy]
+		if !ok {
+			t.Errorf("expected legacy resource %q to remain registered (deprecated alias)", legacy)
+		} else if !lg.deprecated {
+			t.Errorf("legacy resource %q must be marked deprecated", legacy)
+		}
+	}
+
+	if len(seen) != len(expected)*2 {
+		t.Errorf("expected %d registered resources, got %d", len(expected)*2, len(seen))
+	}
+
+	for name := range seen {
+		if name == "" {
+			t.Error("found a resource with an empty type name")
+		}
+		if !strings.HasPrefix(name, "project") && !strings.HasPrefix(name, "jfrog_project") {
+			t.Errorf("unexpected resource type name %q", name)
+		}
+	}
+}

--- a/pkg/project/resource/resource_project.go
+++ b/pkg/project/resource/resource_project.go
@@ -39,13 +39,24 @@ var customRoleTypeRegex = regexp.MustCompile(fmt.Sprintf("^%s$", customRoleType)
 
 func NewProjectResource() resource.Resource {
 	return &ProjectResource{
-		TypeName: "project",
+		TypeName: "jfrog_project",
+	}
+}
+
+// NewProjectResourceDeprecated registers the legacy, un-namespaced resource
+// name. It is deprecated in favor of jfrog_project and will be removed in the
+// next major release.
+func NewProjectResourceDeprecated() resource.Resource {
+	return &ProjectResource{
+		TypeName:           "project",
+		DeprecationMessage: "Use `jfrog_project` instead. The `project` resource name is deprecated and will be removed in the next major release of the provider.",
 	}
 }
 
 type ProjectResource struct {
-	ProviderData util.ProviderMetadata
-	TypeName     string
+	ProviderData       util.ProviderMetadata
+	TypeName           string
+	DeprecationMessage string
 }
 
 type ProjectResourceModelV1 struct {
@@ -406,7 +417,7 @@ type ProjectAPIModel struct {
 }
 
 func (r *ProjectResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName
+	resp.TypeName = r.TypeName
 }
 
 var schemaV1 = schema.Schema{
@@ -684,7 +695,8 @@ var schemaV3 = schema.Schema{
 
 func (r *ProjectResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Version: 4,
+		DeprecationMessage: r.DeprecationMessage,
+		Version:            4,
 		Attributes: lo.Assign(schemaV3.Attributes, map[string]schema.Attribute{
 			"use_project_repository_resource": schema.BoolAttribute{
 				Optional:    true,

--- a/pkg/project/resource/resource_project_environment.go
+++ b/pkg/project/resource/resource_project_environment.go
@@ -24,13 +24,24 @@ const ProjectEnvironmentUrl = "/access/api/v1/projects/{projectKey}/environments
 
 func NewProjectEnvironmentResource() resource.Resource {
 	return &ProjectEnvironmentResource{
-		TypeName: "project_environment",
+		TypeName: "jfrog_project_environment",
+	}
+}
+
+// NewProjectEnvironmentResourceDeprecated registers the legacy, un-namespaced
+// resource name. It is deprecated in favor of jfrog_project_environment and
+// will be removed in the next major release.
+func NewProjectEnvironmentResourceDeprecated() resource.Resource {
+	return &ProjectEnvironmentResource{
+		TypeName:           "project_environment",
+		DeprecationMessage: "Use `jfrog_project_environment` instead. The `project_environment` resource name is deprecated and will be removed in the next major release of the provider.",
 	}
 }
 
 type ProjectEnvironmentResource struct {
-	ProviderData util.ProviderMetadata
-	TypeName     string
+	ProviderData       util.ProviderMetadata
+	TypeName           string
+	DeprecationMessage string
 }
 
 type ProjectEnvironmentResourceModel struct {
@@ -53,7 +64,8 @@ func (r *ProjectEnvironmentResource) Metadata(ctx context.Context, req resource.
 
 func (r *ProjectEnvironmentResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Version: 1,
+		DeprecationMessage: r.DeprecationMessage,
+		Version:            1,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/pkg/project/resource/resource_project_group.go
+++ b/pkg/project/resource/resource_project_group.go
@@ -24,13 +24,24 @@ const ProjectGroupsUrl = "access/api/v1/projects/{projectKey}/groups/{name}"
 
 func NewProjectGroupResource() resource.Resource {
 	return &ProjectGroupResource{
-		TypeName: "project_group",
+		TypeName: "jfrog_project_group",
+	}
+}
+
+// NewProjectGroupResourceDeprecated registers the legacy, un-namespaced
+// resource name. It is deprecated in favor of jfrog_project_group and will be
+// removed in the next major release.
+func NewProjectGroupResourceDeprecated() resource.Resource {
+	return &ProjectGroupResource{
+		TypeName:           "project_group",
+		DeprecationMessage: "Use `jfrog_project_group` instead. The `project_group` resource name is deprecated and will be removed in the next major release of the provider.",
 	}
 }
 
 type ProjectGroupResource struct {
-	ProviderData util.ProviderMetadata
-	TypeName     string
+	ProviderData       util.ProviderMetadata
+	TypeName           string
+	DeprecationMessage string
 }
 
 type ProjectGroupResourceModel struct {
@@ -51,7 +62,8 @@ func (r *ProjectGroupResource) Metadata(ctx context.Context, req resource.Metada
 
 func (r *ProjectGroupResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Version: 1,
+		DeprecationMessage: r.DeprecationMessage,
+		Version:            1,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/pkg/project/resource/resource_project_namespacing_test.go
+++ b/pkg/project/resource/resource_project_namespacing_test.go
@@ -1,0 +1,67 @@
+package project_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	acctest "github.com/jfrog/terraform-provider-project/pkg/project/acctest"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+// TestAccProject_namespacedName verifies Phase 1 of issue #210: the new
+// `jfrog_project` resource name works end-to-end (create/read/update).
+func TestAccProject_namespacedName(t *testing.T) {
+	name := fmt.Sprintf("tftestprojects%s", acctest.RandSeq(10))
+	resourceName := fmt.Sprintf("jfrog_project.%s", name)
+	key := strings.ToLower(acctest.RandSeq(6))
+
+	config := util.ExecuteTemplate("TestAccProjectNamespaced", `
+		resource "jfrog_project" "{{ .name }}" {
+			key          = "{{ .project_key }}"
+			display_name = "{{ .name }}"
+			description  = "test description"
+			admin_privileges {
+				manage_members           = true
+				manage_resources         = true
+				manage_remote_repository = true
+				index_resources          = true
+			}
+			max_storage_in_gibibytes   = 1
+			block_deployments_on_limit = true
+			email_notification         = false
+		}
+	`, map[string]interface{}{
+		"name":        name,
+		"project_key": key,
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		CheckDestroy:             acctest.VerifyDeleted(resourceName, verifyProject),
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "key", key),
+					resource.TestCheckResourceAttr(resourceName, "display_name", name),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     key,
+				ImportStateVerify: true,
+				// Config-only attributes that are not returned by the API on import.
+				ImportStateVerifyIgnore: []string{
+					"use_project_group_resource",
+					"use_project_repository_resource",
+					"use_project_role_resource",
+					"use_project_user_resource",
+				},
+			},
+		},
+	})
+}

--- a/pkg/project/resource/resource_project_repository.go
+++ b/pkg/project/resource/resource_project_repository.go
@@ -25,13 +25,24 @@ const repositoryEndpoint = "/artifactory/api/repositories/{key}"
 
 func NewProjectRepositoryResource() resource.Resource {
 	return &ProjectRepositoryResource{
-		TypeName: "project_repository",
+		TypeName: "jfrog_project_repository",
+	}
+}
+
+// NewProjectRepositoryResourceDeprecated registers the legacy, un-namespaced
+// resource name. It is deprecated in favor of jfrog_project_repository and will
+// be removed in the next major release.
+func NewProjectRepositoryResourceDeprecated() resource.Resource {
+	return &ProjectRepositoryResource{
+		TypeName:           "project_repository",
+		DeprecationMessage: "Use `jfrog_project_repository` instead. The `project_repository` resource name is deprecated and will be removed in the next major release of the provider.",
 	}
 }
 
 type ProjectRepositoryResource struct {
-	ProviderData util.ProviderMetadata
-	TypeName     string
+	ProviderData       util.ProviderMetadata
+	TypeName           string
+	DeprecationMessage string
 }
 
 type ProjectRepositoryResourceModel struct {
@@ -51,7 +62,8 @@ func (r *ProjectRepositoryResource) Metadata(ctx context.Context, req resource.M
 
 func (r *ProjectRepositoryResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Version: 1,
+		DeprecationMessage: r.DeprecationMessage,
+		Version:            1,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/pkg/project/resource/resource_project_role.go
+++ b/pkg/project/resource/resource_project_role.go
@@ -66,13 +66,24 @@ var validRoleActions = []string{
 
 func NewProjectRoleResource() resource.Resource {
 	return &ProjectRoleResource{
-		TypeName: "project_role",
+		TypeName: "jfrog_project_role",
+	}
+}
+
+// NewProjectRoleResourceDeprecated registers the legacy, un-namespaced resource
+// name. It is deprecated in favor of jfrog_project_role and will be removed in
+// the next major release.
+func NewProjectRoleResourceDeprecated() resource.Resource {
+	return &ProjectRoleResource{
+		TypeName:           "project_role",
+		DeprecationMessage: "Use `jfrog_project_role` instead. The `project_role` resource name is deprecated and will be removed in the next major release of the provider.",
 	}
 }
 
 type ProjectRoleResource struct {
-	ProviderData util.ProviderMetadata
-	TypeName     string
+	ProviderData       util.ProviderMetadata
+	TypeName           string
+	DeprecationMessage string
 }
 
 type ProjectRoleResourceModel struct {
@@ -97,7 +108,8 @@ func (r *ProjectRoleResource) Metadata(ctx context.Context, req resource.Metadat
 
 func (r *ProjectRoleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Version: 1,
+		DeprecationMessage: r.DeprecationMessage,
+		Version:            1,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/pkg/project/resource/resource_project_share_repository.go
+++ b/pkg/project/resource/resource_project_share_repository.go
@@ -25,13 +25,24 @@ const shareWithTargetProject = "access/api/v1/projects/_/share/repositories/{rep
 
 func NewProjectShareRepositoryResource() resource.Resource {
 	return &ProjectShareRepositoryResource{
-		TypeName: "project_share_repository",
+		TypeName: "jfrog_project_share_repository",
+	}
+}
+
+// NewProjectShareRepositoryResourceDeprecated registers the legacy,
+// un-namespaced resource name. It is deprecated in favor of
+// jfrog_project_share_repository and will be removed in the next major release.
+func NewProjectShareRepositoryResourceDeprecated() resource.Resource {
+	return &ProjectShareRepositoryResource{
+		TypeName:           "project_share_repository",
+		DeprecationMessage: "Use `jfrog_project_share_repository` instead. The `project_share_repository` resource name is deprecated and will be removed in the next major release of the provider.",
 	}
 }
 
 type ProjectShareRepositoryResource struct {
-	ProviderData util.ProviderMetadata
-	TypeName     string
+	ProviderData       util.ProviderMetadata
+	TypeName           string
+	DeprecationMessage string
 }
 
 type ProjectShareRepositoryResourceModel struct {
@@ -46,6 +57,7 @@ func (r *ProjectShareRepositoryResource) Metadata(ctx context.Context, req resou
 
 func (r *ProjectShareRepositoryResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		DeprecationMessage: r.DeprecationMessage,
 		Attributes: map[string]schema.Attribute{
 			"repo_key": schema.StringAttribute{
 				Required: true,

--- a/pkg/project/resource/resource_project_share_repository_with_all.go
+++ b/pkg/project/resource/resource_project_share_repository_with_all.go
@@ -23,13 +23,25 @@ const shareWithAllProjectsEndpoint = "access/api/v1/projects/_/share/repositorie
 
 func NewProjectShareRepositoryWithAllResource() resource.Resource {
 	return &ProjectShareRepositoryWithAllResource{
-		TypeName: "project_share_repository_with_all",
+		TypeName: "jfrog_project_share_repository_with_all",
+	}
+}
+
+// NewProjectShareRepositoryWithAllResourceDeprecated registers the legacy,
+// un-namespaced resource name. It is deprecated in favor of
+// jfrog_project_share_repository_with_all and will be removed in the next major
+// release.
+func NewProjectShareRepositoryWithAllResourceDeprecated() resource.Resource {
+	return &ProjectShareRepositoryWithAllResource{
+		TypeName:           "project_share_repository_with_all",
+		DeprecationMessage: "Use `jfrog_project_share_repository_with_all` instead. The `project_share_repository_with_all` resource name is deprecated and will be removed in the next major release of the provider.",
 	}
 }
 
 type ProjectShareRepositoryWithAllResource struct {
-	ProviderData util.ProviderMetadata
-	TypeName     string
+	ProviderData       util.ProviderMetadata
+	TypeName           string
+	DeprecationMessage string
 }
 
 type ProjectShareRepositoryWithAllResourceModel struct {
@@ -43,6 +55,7 @@ func (r *ProjectShareRepositoryWithAllResource) Metadata(ctx context.Context, re
 
 func (r *ProjectShareRepositoryWithAllResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		DeprecationMessage: r.DeprecationMessage,
 		Attributes: map[string]schema.Attribute{
 			"repo_key": schema.StringAttribute{
 				Required: true,

--- a/pkg/project/resource/resource_project_user.go
+++ b/pkg/project/resource/resource_project_user.go
@@ -25,13 +25,24 @@ const ProjectUsersUrl = "access/api/v1/projects/{projectKey}/users/{name}"
 
 func NewProjectUserResource() resource.Resource {
 	return &ProjectUserResource{
-		TypeName: "project_user",
+		TypeName: "jfrog_project_user",
+	}
+}
+
+// NewProjectUserResourceDeprecated registers the legacy, un-namespaced resource
+// name. It is deprecated in favor of jfrog_project_user and will be removed in
+// the next major release.
+func NewProjectUserResourceDeprecated() resource.Resource {
+	return &ProjectUserResource{
+		TypeName:           "project_user",
+		DeprecationMessage: "Use `jfrog_project_user` instead. The `project_user` resource name is deprecated and will be removed in the next major release of the provider.",
 	}
 }
 
 type ProjectUserResource struct {
-	ProviderData util.ProviderMetadata
-	TypeName     string
+	ProviderData       util.ProviderMetadata
+	TypeName           string
+	DeprecationMessage string
 }
 
 type ProjectUserResourceModel struct {
@@ -53,7 +64,8 @@ func (r *ProjectUserResource) Metadata(ctx context.Context, req resource.Metadat
 
 func (r *ProjectUserResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Version: 1,
+		DeprecationMessage: r.DeprecationMessage,
+		Version:            1,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/templates/guides/migrating_to_jfrog_namespace.md
+++ b/templates/guides/migrating_to_jfrog_namespace.md
@@ -1,0 +1,79 @@
+---
+page_title: "Migrating to the jfrog_ namespace"
+subcategory: "Guides"
+description: |-
+  How to migrate from the deprecated un-namespaced resource names to the new jfrog_ namespaced resources.
+---
+
+# Migrating to the `jfrog_` namespace
+
+Starting with v1.10.0, every resource in this provider is available under the
+`jfrog_` namespace (for example `jfrog_project` instead of `project`). The old,
+un-namespaced names still work but are **deprecated** and will be removed in the
+next major release.
+
+| Deprecated name                     | New name                                  |
+|-------------------------------------|-------------------------------------------|
+| `project`                           | `jfrog_project`                           |
+| `project_environment`               | `jfrog_project_environment`               |
+| `project_group`                     | `jfrog_project_group`                     |
+| `project_repository`                | `jfrog_project_repository`                |
+| `project_role`                      | `jfrog_project_role`                      |
+| `project_share_repository`          | `jfrog_project_share_repository`          |
+| `project_share_repository_with_all` | `jfrog_project_share_repository_with_all` |
+| `project_user`                      | `jfrog_project_user`                      |
+
+## 1. Update the provider local name
+
+Terraform derives the provider from a resource's type prefix. The deprecated
+names (`project`, `project_*`) resolve to the local name `project`, while the
+new `jfrog_*` names resolve to the local name `jfrog`. Update your
+`required_providers` block so the provider is configured under `jfrog`:
+
+```terraform
+terraform {
+  required_providers {
+    jfrog = {
+      source  = "jfrog/project"
+      version = "~> 1.10"
+    }
+  }
+}
+
+provider "jfrog" {
+  url          = "https://myinstance.jfrog.io"
+  access_token = var.access_token
+}
+```
+
+## 2. Rename the resources and add `moved` blocks
+
+Renaming a resource type is **not** an automatic operation in Terraform. Use a
+`moved` block so existing state is migrated in place instead of the resource
+being destroyed and recreated:
+
+```terraform
+resource "jfrog_project" "myproject" {
+  key          = "myproj"
+  display_name = "My Project"
+  # ...
+}
+
+moved {
+  from = project.myproject
+  to   = jfrog_project.myproject
+}
+```
+
+Apply the change and confirm the plan reports a move (not a destroy/create).
+Once applied, the `moved` block can be removed.
+
+~> **Warning:** If you rename a resource without a `moved` block (or without
+running `terraform state mv`), Terraform will plan to **destroy** the old
+resource and **create** a new one, which can be disruptive for resources such as
+`jfrog_project`.
+
+## 3. Remove the deprecated provider configuration
+
+After all resources are migrated, remove the old `project` local name from
+`required_providers` and delete any `provider "project"` blocks.

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -25,6 +25,8 @@ curl -sL ${host}/projects/api/system/licenses/ | jq .
 
 ## Example Usage
 
+~> As of v1.10.0 the resources are namespaced under the `jfrog_` prefix (e.g. `jfrog_project`) and the provider is configured under the `jfrog` local name. The previous un-namespaced resource names (`project`, `project_*`) still work but are deprecated. See the [Migrating to the `jfrog_` namespace](guides/migrating_to_jfrog_namespace) guide.
+
 {{tffile "examples/full.tf"}}
 
 ## Authentication
@@ -40,7 +42,7 @@ Artifactory access tokens may be used via the Authorization header by providing 
 Usage:
 ```hcl
 # Configure the Artifactory provider
-provider "project" {
+provider "jfrog" {
   url = "projects.site.com/projects"
   access_token = "abc...xy"
 }
@@ -85,14 +87,14 @@ terraform {
   }
 
   required_providers {
-    project = {
+    jfrog = {
       source  = "jfrog/project"
-      version = "1.6.0"
+      version = "1.10.0"
     }
   }
 }
 
-provider "project" {
+provider "jfrog" {
   url = "https://myinstance.jfrog.io"
   oidc_provider_name = "terraform-cloud"
   tfc_credential_tag_name = "JFROG"


### PR DESCRIPTION
# feat(namespacing): add `jfrog_` namespaced resources with deprecated aliases for legacy names

## Summary

Implements **Phase 1** of [#210](https://github.com/jfrog/terraform-provider-project/issues/210).

Every resource is now available under the `jfrog_` namespace (e.g. `jfrog_project`), making it clear the resources belong to the JFrog Platform and conforming to the `<provider>_<resource>` naming convention expected by the ecosystem — including Crossplane Upjet, which cannot consume un-namespaced resources. The previous un-namespaced names (`project`, `project_*`) continue to work but are now **deprecated** and will be removed in the next major release (Phase 2).

This release is backward compatible, so it is versioned as a minor release (`1.10.0`).

| Primary (new)                             | Deprecated alias (still works)      |
|-------------------------------------------|-------------------------------------|
| `jfrog_project`                           | `project`                           |
| `jfrog_project_environment`               | `project_environment`               |
| `jfrog_project_group`                     | `project_group`                     |
| `jfrog_project_repository`                | `project_repository`                |
| `jfrog_project_role`                      | `project_role`                      |
| `jfrog_project_share_repository`          | `project_share_repository`          |
| `jfrog_project_share_repository_with_all` | `project_share_repository_with_all` |
| `jfrog_project_user`                      | `project_user`                      |

## Implementation

- Each resource struct gained a `DeprecationMessage` field, surfaced through `Schema.DeprecationMessage`. The primary constructor (`New*Resource`) sets the `jfrog_`-prefixed type name with no deprecation; a new `New*ResourceDeprecated` constructor sets the legacy type name plus the deprecation message.
- `provider.go` registers all 16 resources (8 namespaced + 8 deprecated aliases) pointing at the same implementations.
- `ProjectResource.Metadata` previously derived its type name from `req.ProviderTypeName` (unlike the other resources); it now uses the explicit `r.TypeName` field for consistency.
- The Terraform Plugin Framework only requires resource type names to be non-empty and unique (verified in the framework source) — there is no provider-prefix enforcement — so the namespaced and legacy names coexist cleanly.

## Important: provider local name

Terraform resolves a resource's provider from the resource type prefix. The `jfrog_*` names resolve to the **local name `jfrog`**, while the legacy `project`/`project_*` names resolve to the local name `project`. To use the namespaced resources, the provider must be configured under `jfrog`:

```terraform
terraform {
  required_providers {
    jfrog = {
      source  = "jfrog/project"
      version = "~> 1.10"
    }
  }
}
```

The acceptance test provider factory (`acctest.ProtoV6ProviderFactories`) is registered under both `project` and `jfrog` local names to mirror this.

## Testing

- **`TestProvider_resourceNamespacing`** (unit, no Artifactory required): asserts all 16 resources register, that each `jfrog_*` name is non-deprecated and each legacy name is deprecated, and that there are no duplicate or empty type names.
- **`TestAccProject_namespacedName`** (acceptance): exercises the new `jfrog_project` resource end-to-end (create / read / import).
- Existing bare-name acceptance tests (`TestAccProject_UpdateKey`, `TestAccProjectUser_full`, `TestAccProjectEnvironment_*`) pass unchanged, confirming the deprecated aliases remain fully functional.

All acceptance tests were run against a live Artifactory instance (v7.146.27).

## Compatibility / migration impact

- Existing configurations using the un-namespaced names and the `project` local name continue to work; users only see deprecation warnings.
- Migrating to the new names requires (1) configuring the provider under the `jfrog` local name and (2) `moved {}` blocks (or `terraform state mv`) to rename resources in state without destroy/recreate. This is documented in the new **"Migrating to the `jfrog_` namespace"** guide.

## Documentation

- `CHANGELOG.md`: `1.10.0` entry with `FEATURES` and `DEPRECATIONS` sections.
- `templates/guides/migrating_to_jfrog_namespace.md`: migration guide.
- `templates/index.md.tmpl`, `examples/full.tf`, `examples/provider/provider.tf`: updated to the `jfrog` local name and namespaced resources.
- `examples/resources/jfrog_*/`: example files for each new resource name.

> Note: the generated `docs/resources/*.md` pages are produced by `tfplugindocs` (`make doc`) as part of the release pipeline and are not regenerated in this PR. The deprecation notices flow into them automatically from the schema on regeneration.
